### PR TITLE
update: declared full path to files

### DIFF
--- a/content/1.omaspecworks/3.collaborate/index.md
+++ b/content/1.omaspecworks/3.collaborate/index.md
@@ -6,5 +6,5 @@ title: Collaborate
 
 This page provides the following content:
 
-- [Affiliates](affiliates/)
-- [Liaison-Agreements](liaison-agreements/)
+- [Affiliates](/omaspecworks/collaborate/affiliates/)
+- [Liaison-Agreements](/omaspecworks/collaborate/liaison-agreements/)


### PR DESCRIPTION
When navigated back and forward using breadcrumbs, it fails to load files from `affiliates/` and `liaison-agreements/`. By adding a full path to those two in `omaspecsworks/collaborate/affiliates/`, the problem should be resolved. 