### PR TITLE
update: links now open in same window

### DIFF
--- a/components/content/sh-micro-card.vue
+++ b/components/content/sh-micro-card.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="ui.wrapper">
-    <NuxtLink :to="urlWrapper" target="_blank" class="not-prose">
+    <NuxtLink :to="urlWrapper" class="not-prose">
       <div class="relative group">
         <img v-if="urlImage" :src="urlImage" :class="ui.image" :alt="altImage"/>
         <UIcon v-if="icon" :name="icon" :alt="altIcon" dynamic :class="ui.icon" />


### PR DESCRIPTION
From NuxtLink removed `target="_blank"` prop, so by default links now open in the same window.
I will merge this without waiting for reviews. I have set you as reviewers so that both of you now have the information that this changed.