### PR TITLE
Current asside style

### DIFF
--- a/components/app/header.vue
+++ b/components/app/header.vue
@@ -22,7 +22,6 @@
                 </ULink>
               </span>
               <span class="mr-2 text-base">
-                <!-- TODO: provide proper URL -->
                 <ULink to="/contact-us" class="text-black dark:text-golden hover:text-primary">Contact us</ULink>
               </span>
               <slot name="right">
@@ -35,7 +34,7 @@
               <li v-for="link in topLinks" :key="link.path" class="ml-4"
                 :style="{ fontFamily: header.menu.font.type, fontSize: header.menu.font.size }">
                 <ULink :to="link._path"
-                  :class="[{ 'underline decoration-4 underline-offset-[14px] decoration-oma-blue-400 dark:underline dark:decoration-4 dark:underline-offset-[14px] dark:decoration-oma-blue-600 ': isLinkActive(link._path) }, ui.shadow, 'text-black dark:text-golden']">
+                  :class="[{ 'underline decoration-4 underline-offset-[14px] decoration-oma-blue-400 dark:underline dark:decoration-4 dark:underline-offset-[14px] dark:decoration-oma-blue-200 ': isLinkActive(link._path) }, ui.shadow, 'text-black dark:text-golden']">
                   {{ link.title }}
                 </ULink>
               </li>

--- a/components/app/side-menu.vue
+++ b/components/app/side-menu.vue
@@ -22,10 +22,10 @@ const route = useRoute()
 const config = {
   wrapper: '',
   shadow: 'hover:bg-primary-200/[0.7] dark:hover:bg-primary-600',
-  active: 'block border-l-4 dark:border-oma-blue-400 border-oma-blue-400 bg-primary-200 dark:bg-primary-600/[0.7]',
+  active: 'block border-l-4 dark:border-oma-blue-200 border-oma-blue-400 bg-primary-200 dark:bg-primary-600/[0.7]',
   normal: 'block border-l-2 dark:border-neutral-700 border-gray-100-ml-px w-full',
   link: {
-    active: 'text-oma-blue-500 dark:text-oma-blue-400 font-bold',
+    active: 'text-oma-blue-500 dark:text-oma-blue-200 font-bold',
     normal: 'w-full block text-black dark:text-golden hover:text-black dark:hover:text-golden'
   }
 };

--- a/components/app/toc.vue
+++ b/components/app/toc.vue
@@ -38,7 +38,7 @@ const config = {
     active: 'bg-primary-200 dark:bg-primary-600 p-2',
     normal: 'w-full p-2',
     link: {
-        active: 'text-oma-blue-500 dark:text-oma-blue-400 font-bold',
+        active: 'text-oma-blue-500 dark:text-oma-blue-200 font-bold',
         normal: 'w-full block text-black dark:text-golden hover:text-black dark:hover:text-golden'
     }
 };


### PR DESCRIPTION
In this PR I have addressed the following style changes for dark mode:
- the color of the active link and active link indicator on the left aside 
- the color of the active link on the right aside (ToC)
- the color of the underline of the main menus