### PR TITLE
update: style for filters

### DIFF
--- a/ui.config/sh-dynamic-table.ts
+++ b/ui.config/sh-dynamic-table.ts
@@ -8,8 +8,8 @@ export default {
   tbody: 'divide-y divide-gray-300 dark:divide-gray-700',
   tr: {
     base: '',
-    selected: 'bg-gray-300 dark:bg-gray-500',
-    active: 'hover:bg-gray-200 dark:hover:bg-gray-300 cursor-pointer'
+    selected: 'bg-oma-blue-400 hover:bg-oma-blue-300 text-white dark:bg-oma-blue-600 dark:hover:bg-oma-blue-500 dark:text-golden',
+    active: 'hover:bg-neutral-200 dark:hover:bg-neutral-600 cursor-pointer'
   },
   th: {
     base: 'text-left rtl:text-right',


### PR DESCRIPTION
- In this PR, I am resolving issue in dark mode with background color on hover over filters,
![image](https://github.com/user-attachments/assets/bf9ec031-27d2-4d4d-94ca-27671d60b2fa)

- also, selected filters are now in `oma-blue-400` and `dark:oma-blue-600`
![image](https://github.com/user-attachments/assets/2b2906fc-3b14-4d33-ad25-699e2552c445)
