### PR TITLE
feat: rename `api` folder in dist

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,6 +21,9 @@ export default defineNuxtConfig({
     markdown: {
       anchorLinks: false 
     },
+    api: {
+      baseURL: '/site-api/_content'
+    }
   },
 
   ui: {


### PR DESCRIPTION
The `site-api` is put instead of `api` folder in dist