### PR TITLE
[Broken Link] update link to complete portfolio for Ericsson to Product list table

### DIFF
--- a/content/3.lwm2m/40.community/50.product-listing.md
+++ b/content/3.lwm2m/40.community/50.product-listing.md
@@ -424,7 +424,7 @@ Below you can read more about each company's product and how it's utilizing LwM2
     <tr>
       <td>Product Web Page</td>
       <td>
-        <p><a href="www.ericsson.com/en/portfolio/digital-services/cloud-core/cloud-unified-data-management-and-policy/core-network-exposure/composition-engine" target="_blank">Composition Engine</a> grow and evolve your Value Added Services business. Create innovative new services and share key assets to open new revenue streams with Ericsson Composition Engine, part of the Ericsson Service Enablement suite.</p>
+        <p><a href="https://www.ericsson.com/en/portfolio" target="_blank">Composition Engine</a> grow and evolve your Value Added Services business. Create innovative new services and share key assets to open new revenue streams with Ericsson Composition Engine, part of the Ericsson Service Enablement suite.</p>
         <p>The Ericsson Composition Engine is an open, versatile and future proof service exposure and application platform enabling service providers to expose network and business assets enabling totally new revenue streams and business models as well as easily create and combine new and existing Value Added Services.</p>
         <p>The Composition Engine can be used for various use cases in the same deployment.</p>
       </td>


### PR DESCRIPTION
The latest [Composition Engine](https://oma-knowledge-base.openmobilealliance.org/www.ericsson.com/en/portfolio/digital-services/cloud-core/cloud-unified-data-management-and-policy/core-network-exposure/composition-engine) link from the Ericsson Product Page can't be found.
The above link is replaced with the [Complete Ericsson Portfolio](https://www.ericsson.com/en/portfolio).