### PR TITLE
feat: address issue 407

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -12,7 +12,7 @@ export default defineNuxtConfig({
   ],
 
   site: {
-    url: 'https://openmobilealliance.org/', 
+    url: 'https://www.openmobilealliance.org/', 
     name: 'Website of OMA SpecWork as an innovative kind of Standards Development Organization' 
   },
 

--- a/public/events-sitemap.xml
+++ b/public/events-sitemap.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://www.openmobilealliance.org/events/</loc>
+  <lastmod>2024-11-25T21:25:13+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Admin/</loc>
+  <lastmod>2024-11-25T21:25:13+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Utilities/</loc>
+  <lastmod>2024-11-25T21:25:13+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Admin/OMA-TestFest-NDA-2023.pdf</loc>
+  <lastmod>2023-10-11T03:08:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Utilities/Feb-2024/</loc>
+  <lastmod>2024-11-25T21:25:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Utilities/May-23/</loc>
+  <lastmod>2024-11-25T21:25:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Utilities/Nov-23/</loc>
+  <lastmod>2024-11-25T21:25:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Utilities/May-23/OMA%20SpecWorks%20Webinar%20For%20Presentation%20Final.pdf</loc>
+  <lastmod>2023-06-09T16:28:15+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/events/Utilities/Nov-23/OMA-SpecWorks-Workshop-II-Nov-2023.pdf</loc>
+  <lastmod>2023-11-22T10:08:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+
+
+</urlset>

--- a/public/release-sitemap.xml
+++ b/public/release-sitemap.xml
@@ -1,0 +1,2513 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://www.openmobilealliance.org/release/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/3DCAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AC_MO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AddressBookREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AOI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AudioCallREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Billing/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browser_Protocol_Stack/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CallNotificationREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging_Data/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Client_Side_CS_FW/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ConnMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CSEA/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DANE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Data_Object/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DeltaRec/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DevCapREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagVoLTE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM_SC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM_Scheduling/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DMClientAPIfw/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DNS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Download/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DPE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DRM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DWAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DWAPI_3DP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DynNav/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/EFI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/EmailNot/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ENCap/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/EVC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/EVVM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/FUMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GOTAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GPM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GS-CSI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GS_API/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GSSM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GuidelinesREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/GwMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/HTML_Deployment_Suite/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IGA/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IGC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ImageShareREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IMF/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IMPS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IMPS_impl/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/IMS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ISC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/KPIinOMA/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LAO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LAW_MO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LER/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LFC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LightweightM2M/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ListMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LOCSIP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LPPe/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LwM2M_APPDATA/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LWM2M_CONNMGMT/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LWM2M_DevCapMgmt/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LwM2M_EventLog/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LwM2M_Gateway/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LWM2M_LOCKWIPE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LWM2M_PortfolioObj/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LWM2M_SWMGMT/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/LwM2M_VON/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/M2M_Device_Classification/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/M2Minterface/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MEM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MessagingREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MgmtPolicyMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MGPC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MIW/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MLP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MLS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MMMD/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MMS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MO_Design_Guidelines/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MobAd/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MobAR/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MobileCodes/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MobileDomainSMIL/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/MSrchFramework/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/NavSe/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/NGSI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/NGSI_S/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/NotifChanREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_5GNR_Conn/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_ACL/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_APN_Conn/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Bearer_Conn/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Cell_Conn/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Conn_Mon/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Conn_Stat/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_COSE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Device/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Firmware/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Gateway/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Location/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_MQTT_Server/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_OSCORE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Routing/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Security/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_Server/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ObjLwM2M_WLAN_Conn/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OBKG/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OCSP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OGSA/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OIG/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OMA-BOD-IOP-2004-0056R03-Test-Tool-RFI.pdf</loc>
+  <lastmod>2013-09-23T07:36:45+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OneAPIProfileREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OpenCMAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OSE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OSPE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OWSER/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/OWSER_NI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PAL/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ParlayREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PaymentREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PCPS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PDE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PEEM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PIOSE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PoC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PresenceREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PresenceSIMPLE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Privacy/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PSA/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Push/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PushRest/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/PXPROF/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RCC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RCS_Deployment_Suite/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_ACR/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_BotManagement/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_CAB/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_Chat/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_Common/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_CommPatt/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_CustomerProfile/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NETAPI_MsgBCast/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NETAPI_NMS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_QoS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_RCSeProfile/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_RCSProfile/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_RichComms/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NETAPI_Twinning/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_WebRTCSignaling/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/REST_NetAPI_ZonalPresence/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RESTNetAPI_Cap_Disc/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RESTNetAPIFileTransfer/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RICD/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RME/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/RoamAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SACMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SCAB/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SCE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SCIDM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SCOMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SCWS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SEC_CF/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ServUserProf/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ShortMessREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SIMPLE_IM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SIP_Push/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SmaC/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SNeW/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SOAP_NetAPI_Roaming/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SpamRep/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SRM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/STI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SUPL/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SUPLCS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SVG/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/SyncML_Primer/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/TAS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Temp_Org_MO_spec/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Template_NetAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/TerminalLocationREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/TerminalStatusREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/TFP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ThirdPartyCallREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/UAProf/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/UAProf_BPG/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/UCD/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/URI_Schemes/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/UVE/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/V1_0-20100615-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/VideoShareREST/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/VirMO/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/vObject/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/WCSS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/WPBR/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/WPKI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/WRAPI/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/XDM/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/XDM_PRS_IMPL/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/3DCAPI/README.txt</loc>
+  <lastmod>2021-02-23T16:07:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/3DCAPI/V1_0-20210210-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AC_MO/README.txt</loc>
+  <lastmod>2017-01-20T16:36:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AC_MO/V1_0-20080513-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AC_MO/V1_0-20081024-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AC_MO/V1_0_1-20090127-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AddressBookREST/README.txt</loc>
+  <lastmod>2017-01-20T16:36:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AddressBookREST/V1_0-20120207-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AddressBookREST/V1_0-20130212-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AddressBookREST/V1_0-20151023-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AOI/README.txt</loc>
+  <lastmod>2017-01-20T16:36:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AOI/V1_0-20150203-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AOI/V1_0-20170404-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AudioCallREST/README.txt</loc>
+  <lastmod>2017-01-20T16:36:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AudioCallREST/V1_0-20120327-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AudioCallREST/V1_0-20130212-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/AudioCallREST/V1_0-20200226-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/README.txt</loc>
+  <lastmod>2017-01-20T16:38:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/V1_0-20120327-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/V1_0-20130910-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/V1_0-20131120-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Autho4API/V1_0-20141209-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/README.txt</loc>
+  <lastmod>2017-01-20T16:38:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20050203-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20060411-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20070529-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20080226-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20080609-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20080807-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20081010-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20081209-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0-20090212-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_0_1-20130109-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_1-20090324-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_1-20091013-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_1-20100914-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_1-20131029-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_2-20140114-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_2-20170131-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_3-20140114-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BCAST/V1_3-20170131-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Billing/README.txt</loc>
+  <lastmod>2017-01-20T16:38:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Billing/V1-0-20021216-H/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Billing/V1_0-20021216-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BMO/README.txt</loc>
+  <lastmod>2017-01-20T16:39:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BMO/V1_0-20091124-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/BMO/V1_0-20100406-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browser_Protocol_Stack/README.txt</loc>
+  <lastmod>2017-01-20T16:39:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browser_Protocol_Stack/V2_1-20050204-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browser_Protocol_Stack/V2_1-20110315-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/README.txt</loc>
+  <lastmod>2017-01-20T16:40:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/TFP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V1_0-20060209-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_1-20021101-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_1-20031113-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_1-20040816-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_1-20050614-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_1-20061020-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_2-20040609-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_2-20040816-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_2-20050614-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_2-20061020-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_3-20050118-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_3-20050614-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_3-20070227-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_3-20070313-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_3-20080331-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_4-20080128-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_4-20080923-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_4-20110329-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Browsing/V2_5-20171015-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/README.txt</loc>
+  <lastmod>2017-01-20T16:40:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_0-20080826-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_0-20081217-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_0-20090907-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_0-20090922-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_0-20101019-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_0-20121113-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_1-20120904-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CAB/V1_1-20180621-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CallNotificationREST/README.txt</loc>
+  <lastmod>2017-01-20T16:40:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CallNotificationREST/V1_0-20120327-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CallNotificationREST/V1_0-20130212-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CallNotificationREST/V1_0-20200226-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/README.txt</loc>
+  <lastmod>2017-01-20T16:40:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/V1_0-20060711-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/V1_0-20071211-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/V1_0-20081014-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/V1_0-20090212-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/V1_0-20090710-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBCS/V1_0-20111206-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/README.txt</loc>
+  <lastmod>2017-01-20T16:40:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/V1_0-20090203-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/V1_0-20090710-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/V1_0-20090922-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/V1_0-20110719-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CBUS/V1_0-20120228-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/README.txt</loc>
+  <lastmod>2017-01-20T16:40:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_0-20041118-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_0-20060926-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_0-20070208-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_0-20070904-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_1-20090213-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_1-20090728-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_1-20101001-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging/V1_1-20121009-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging_Data/README.txt</loc>
+  <lastmod>2017-01-20T16:40:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging_Data/V1_0-20090310-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging_Data/V1_0-20090714-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging_Data/V1_0-20100825-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Charging_Data/V1_0-20110201-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Client_Side_CS_FW/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Client_Side_CS_FW/README.txt</loc>
+  <lastmod>2017-01-20T16:41:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Client_Side_CS_FW/V1_0-20041118-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Client_Side_CS_FW/V1_0-20060209-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Client_Side_CS_FW/V1_0-20070614-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/README.txt</loc>
+  <lastmod>2017-01-20T16:41:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/V1_1-20021115-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/V1_1-20040324-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/V1_1-20040720-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/v1_1-20050428-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/V1_1-20080226-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/V1_1-20090421-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ClientProv/V1_1-20090728-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMI/README.txt</loc>
+  <lastmod>2017-01-20T16:41:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMI/V1_0-20090127-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMI/V1_0-20090922-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMI/V1_0-20091201-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMI/V1_0-20110705-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/README.txt</loc>
+  <lastmod>2017-01-20T16:41:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/V1_0-20081216-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/V1_0-20090602-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/V1_0-20091013-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/V1_0-20100706-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CMR/V1_0-20120320-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/README.txt</loc>
+  <lastmod>2017-01-20T16:41:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/V1_1_2-20030612-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/V1_1_2-20040711-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/V1_2-20040601-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/v1_2-20050509-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/V1_2-20070221-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/V1_2_1-20070813-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Common/V1_2_2-20090724-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ConnMO/V1_0-20051206-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ConnMO/V1_0-20051206-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ConnMO/V1_0-20080812-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/ConnMO/V1_0-20081107-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/README.txt</loc>
+  <lastmod>2017-01-20T16:41:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V1_0-20071106-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V1_0-20090310-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V1_0-20101012-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V1_0-20120612-H/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V2_0-20130611-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V2_0-20150113-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V2_0-20150113-H/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V2_1-20160209-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V2_2-20170926-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPM/V2_2-20200907-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/README.txt</loc>
+  <lastmod>2017-01-20T16:41:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_0-20091117-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_0-20100615-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_0-20110503-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_0-20120327-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_0-20121023-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_0_1-20131015-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_1-20120313-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_1-20120529-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_1-20130402-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CPNS/V1_1-20160209-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CSEA/README.txt</loc>
+  <lastmod>2017-01-20T16:41:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CSEA/V1_0-20100427-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/CSEA/V1_0-20101130-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DANE/README.txt</loc>
+  <lastmod>2017-01-20T16:41:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DANE/V1_0-20130507-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DANE/V1_0-20140318-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DANE/V1_0-20150113-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Data_Object/README.txt</loc>
+  <lastmod>2017-01-20T16:41:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Data_Object/V1_0-20080506-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/Data_Object/V1_0-20080916-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/README.txt</loc>
+  <lastmod>2017-01-20T16:41:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20060530-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20070716-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20081223-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20090612-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20091026-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20100303-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCD/V1_0-20110705-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/README.txt</loc>
+  <lastmod>2017-01-20T16:42:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20070529-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20070625-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20081024-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20090317-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20090904-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20101102-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20110531-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20110704-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DCMO/V1_0-20120410-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DeltaRec/README.txt</loc>
+  <lastmod>2017-01-20T16:42:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DeltaRec/V1_0-20110927-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DeltaRec/V1_0-20130410-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DeltaRec/V1_0-20130521-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DevCapREST/README.txt</loc>
+  <lastmod>2017-01-20T16:42:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DevCapREST/V1_0-20111220-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DevCapREST/V1_0-20130212-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DevCapREST/V1_0-20130924-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DevCapREST/V1_0_1-20151123-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/README.txt</loc>
+  <lastmod>2017-01-20T16:42:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20070209-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20090414-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20090610-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20100420-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20101102-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20110527-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_0-20120313-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_1-20100622-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_1-20101129-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_1-20111220-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_2-20121009-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_2-20121102-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_2-20121121-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagMon/V1_2-20131008-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagVoLTE/README.txt</loc>
+  <lastmod>2017-01-20T16:42:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagVoLTE/V1_0-20141125-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DiagVoLTE/V1_0-20150526-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/cp_V1_0-20130430-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/README.txt</loc>
+  <lastmod>2017-01-20T16:43:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_1_2-20031209-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_1_2-20040113-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20050607-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20050628-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20050729-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20050826-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20051216-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20060208-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20060309-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20060424-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20060602-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2-20070209-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_2_1-20080617-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20090602-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20090901-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20090922-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20100525-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20101207-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20120306-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20121009-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20121213-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20130422-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V1_3-20160524-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20100309-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20100720-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20111220-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20120306-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20120531-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20131210-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20150122-C/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM/V2_0-20160209-A/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM_SC/ETS/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM_SC/EVP/</loc>
+  <lastmod>2024-11-25T21:30:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/release/DM_SC/README.txt</loc>
+  <lastmod>2017-01-20T16:43:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+
+
+</urlset>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,13 @@
 User-agent: *
 Disallow: /site-api/
+Disallow: /Technical/
+Disallow: /release_program/
+
 Allow: /
 
-Sitemap: https://openmobilealliance.org/sitemap.xml
+Sitemap: https://www.openmobilealliance.org/sitemap.xml
+
+Sitemap: https://www.openmobilealliance.org/events-sitemap.xml
+Sitemap: https://www.openmobilealliance.org/release-sitemap.xml
+Sitemap: https://www.openmobilealliance.org/tech-sitemap.xml
+Sitemap: https://www.openmobilealliance.org/test_events-sitemap.xml

--- a/public/tech-sitemap.xml
+++ b/public/tech-sitemap.xml
@@ -1,0 +1,2513 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://www.openmobilealliance.org/tech/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/extref/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/OMASpecWorks/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/pre-reg/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/</loc>
+  <lastmod>2024-11-25T21:32:02+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/ila/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/LicenseAgreement.asp</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mgif/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/wap/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/wv/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/ac_ap0008_SIMPLE_IM-v1_0.txt</loc>
+  <lastmod>2015-03-24T08:51:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/dd.xsd</loc>
+  <lastmod>2003-11-17T10:51:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/dm_dm13_delegationprotocol-v1_0.xsd</loc>
+  <lastmod>2016-06-10T10:10:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/mms_mtd-v1_3.xsd</loc>
+  <lastmod>2008-09-25T13:41:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/readme_MLP_320_V1_0-20100831-C.txt</loc>
+  <lastmod>2010-11-19T14:17:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/readme_MLP_320_V1_0-20110719-A.txt</loc>
+  <lastmod>2011-07-26T15:00:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/readme_RLP_100-V1_0-20100831-C.txt</loc>
+  <lastmod>2010-11-19T14:17:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/dtd/readme_RLP_100-V1_0-20110719-A.txt</loc>
+  <lastmod>2011-07-26T15:00:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/extref/OMA-TS-REST_NetAPI_ACR-V1_0.pdf</loc>
+  <lastmod>2015-12-11T13:26:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/OMASpecWorks/OMA-TestFest-NDA-2017.pdf</loc>
+  <lastmod>2018-08-08T21:52:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/OMASpecWorks/OMASpecWorks%20FAQ%20.pdf</loc>
+  <lastmod>2018-06-01T15:18:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/ddf/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/dm-ac/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/dm-mo/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/dm_mo/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/evvm/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/prs-mo/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/prs_mo/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/test/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/WINA20020204v01.pdf</loc>
+  <lastmod>2013-10-11T05:18:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omna/xdm_mo/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/_notes/</loc>
+  <lastmod>2024-11-25T21:35:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_am-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_am-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_am-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_fd_associatedprocedure-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_fd_backend-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_fd_fdt-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_fd_receptionreport-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_fd_receptionreport-v1_0_1.xsd</loc>
+  <lastmod>2017-02-13T09:58:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_backend-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_backend-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_backend-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_backend-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_message-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_message-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_message-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_nt_message-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_pr_orderqueries-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_pr_orderqueries-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_pr_orderqueries-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_pr_orderqueries-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_pr_userpreference-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_backend-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:11:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_backend-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_backend-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_backend-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_frontend-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_frontend-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_frontend-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_roaming_frontend-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sd_associatedprocedure-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sd_backend-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sd_receptionreport-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_backend-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_backend-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_backend-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_backend-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_fragments-v1_0.xsd</loc>
+  <lastmod>2021-04-19T14:45:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_fragments-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_fragments-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_fragments-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_sgdd-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_sgdd-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_sgdd-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_sg_sgdd-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_si_interactivitymedia-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_si_interactivitymedia-v1_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_si_interactivitymedia-v1_2.xsd</loc>
+  <lastmod>2017-02-13T09:55:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_si_interactivitymedia-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_spcp_backend-v1_0.xsd</loc>
+  <lastmod>2013-11-26T15:40:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_spcp_backend-v1_0_1.xsd</loc>
+  <lastmod>2017-02-13T09:55:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/bcast_spcp_backend-v1_3.xsd</loc>
+  <lastmod>2017-02-13T09:58:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_ab-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_ab-v1_1.xsd</loc>
+  <lastmod>2018-08-06T10:00:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_feature_handler-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:11:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_feature_handler-v1_1.xsd</loc>
+  <lastmod>2018-08-08T08:26:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_pcc-v1_0.xsd</loc>
+  <lastmod>2017-08-30T08:46:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_pcc-v1_1.xsd</loc>
+  <lastmod>2018-08-06T10:02:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_search_external_directories-v1_0.xsd</loc>
+  <lastmod>2018-08-06T10:03:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_user_preferences-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cab_user_preferences-v1_1.xsd</loc>
+  <lastmod>2018-08-06T10:03:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cbcs_pem1InputTemplate-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cbcs_pem1OutputTemplate-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/cmi_package-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/CMR_messages-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dcd_xsd-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dd-V2_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dd.xsd</loc>
+  <lastmod>2013-10-03T09:09:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dd_midpjad-V2_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DDF.XSD</loc>
+  <lastmod>2018-06-13T05:22:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DDF1.XSD</loc>
+  <lastmod>2019-02-06T01:17:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DDF2.XSD</loc>
+  <lastmod>2019-02-19T07:53:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dm-deltarec_deltarecord-v1_0.txt</loc>
+  <lastmod>2013-10-03T09:07:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dm-deltarec_deltarecord-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dm_diag12_nfc-v1_1.xsd</loc>
+  <lastmod>2013-10-22T16:04:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dm_diag12_trapeventlogging-v1_0.xsd</loc>
+  <lastmod>2013-10-22T16:04:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dm_dm13_delegationprotocol-v1_0.xsd</loc>
+  <lastmod>2016-06-10T10:12:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/dpe_xsd-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DRM/</loc>
+  <lastmod>2024-11-25T21:36:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_dd_xbs-v2_0.xsd</loc>
+  <lastmod>2013-11-26T15:40:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_dd_xbs-v2_0_1.xsd</loc>
+  <lastmod>2017-02-13T09:58:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_lrm_v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_rel-v2_2.xsd</loc>
+  <lastmod>2013-10-03T09:06:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_rel_dd-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_rel_ex-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_rel_ex-v2_2.xsd</loc>
+  <lastmod>2013-10-03T09:07:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_rel_odd-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_rel_odd-v2_2.xsd</loc>
+  <lastmod>2013-10-03T09:06:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_risd-v1_0.xsd</loc>
+  <lastmod>2017-02-13T09:58:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_roap-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:07:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DRM_ROAP-v2_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_roap-v2_2.xsd</loc>
+  <lastmod>2013-10-03T09:08:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_roap_xbs-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_roap_xbs-v2_1.xsd</loc>
+  <lastmod>2013-11-26T15:40:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/drm_roap_xbs-v2_1_1.xsd</loc>
+  <lastmod>2017-02-13T09:58:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DS_DevInf_Schema-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/DS_Syntax_Schema-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/EVC_EnrichedInfo-V1_0.xsd</loc>
+  <lastmod>2018-08-06T11:02:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/EVC_VisualIVRMapping-V1_0.xsd</loc>
+  <lastmod>2018-08-06T11:01:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/EVC_VisualIVRRequest-V1_0.xsd</loc>
+  <lastmod>2018-08-06T11:02:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/EVC_VisualIVRResponse-V1_0.xsd</loc>
+  <lastmod>2018-08-06T11:02:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-cp-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-deac-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-gsp-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-pref-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-ssp-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-sync-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-tran-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/evvm-up-v1_0.xsd</loc>
+  <lastmod>2015-09-28T14:35:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/GPM_PEM1InputTemplate-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/GPM_PEM1OutputTemplate-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/gssm_gssm1-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/gssm_gssm2-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/gssm_pem1InputTemplate-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/gssm_pem1OutputTemplate-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/gssm_queries-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/im_hist_def_metadata-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/im_hist_def_metadata-V1_1.xsd</loc>
+  <lastmod>2015-03-23T16:36:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/im_service_settings-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/im_service_settings-v1_1.xsd</loc>
+  <lastmod>2015-03-23T16:36:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/isc_contents_list-v1_0.xsd</loc>
+  <lastmod>2015-07-06T09:59:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/isc_group_ext-v1_0.xsd</loc>
+  <lastmod>2015-07-06T09:59:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/isc_user_preferences-v1_0.xsd</loc>
+  <lastmod>2015-07-06T09:59:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/JSD/</loc>
+  <lastmod>2024-11-25T21:37:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/KPIinOMA_messages-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:11:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/LFC_Package_Metadata_Schema-v1_0.txt</loc>
+  <lastmod>2013-10-03T09:09:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/LFC_Package_Metadata_Schema-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/locsip_filter-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/locsip_gbakeyid-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/locsip_geolocation_policy_v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/locsip_geolocation_policy_v1_0.xsd.txt</loc>
+  <lastmod>2013-10-03T09:08:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/locsip_gpmpem1outputext-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/locsip_qos-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/lwm2m/</loc>
+  <lastmod>2024-11-25T21:37:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/lwm2m-archive/</loc>
+  <lastmod>2024-11-25T21:37:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/LWM2M-v1_1.xsd</loc>
+  <lastmod>2018-08-07T08:35:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/LWM2M.xsd</loc>
+  <lastmod>2017-01-14T12:03:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/LWM2M_old.XSD</loc>
+  <lastmod>2017-01-20T08:36:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/LWM2M_senml_units.xsd</loc>
+  <lastmod>2020-01-16T18:45:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/mc_xs-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/MMS/</loc>
+  <lastmod>2024-11-25T21:37:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/mms_mtd-v1_3.xsd</loc>
+  <lastmod>2013-10-03T09:11:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/mobad_messages-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/MSrch_messages-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:28+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/MSrch_userinfo-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/Official-Registry/</loc>
+  <lastmod>2024-11-25T21:37:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-DD-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-SUP-AC_ap0002_presence-V1_0_1-20061128-A.txt</loc>
+  <lastmod>2013-10-03T09:07:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-SUP-XSD_DD-V2_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-SUP-XSD_rest_DynNav-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-SUP-XSD_SCE_DOM-V1_0-20110705-A.xsd</loc>
+  <lastmod>2013-10-03T09:08:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-SUP-XSD_SCE_DOM-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/OMA-SUP-XSD_SCE_GEN-20110705-A.xsd</loc>
+  <lastmod>2013-10-03T09:05:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pal_messagePayloads-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_detProgressRep-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_dispatchInd-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_FDCFO-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_finalReport-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_group_advertisement-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_limitedParticipantInfoReq-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_listService-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_optProgressRep-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc2_0_Rules-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc2_0Settings-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc2_0SharedGroupExt-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc2_1_ParticipantInfoInd-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:28+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc2_1_Settings-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc2_1_SharedGroupExt-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_poc_sessions-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_pocusage-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pcps_sessionInvocationDescriptor-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:09:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pde_palBasePolicy-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pde_pidf_ext-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pde_pidf_ext-v1_2.xsd</loc>
+  <lastmod>2016-01-19T01:12:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pde_pidf_ext.xsd</loc>
+  <lastmod>2013-10-03T09:08:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/peem_ruleset-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/PEM_1_GenericInputTemplateData-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/PEM_1_GenericOutputTemplateData-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/POC/</loc>
+  <lastmod>2024-11-25T21:38:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc2_1ParticipantInfoInd-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_detProgressRep-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_dispatchInd-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_FDCFO-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_finalReport-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_group_advertisement-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_group_advertisement-V1_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:07:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_limitedParticipantInfoReq-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:06:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_listService-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_listService-V1_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_optProgressRep-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_participantInfoInd-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_poc2_0Rules-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_poc2_0Settings-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_poc2_0SharedGroupExt-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_poc2_1Settings-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:09:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_poc2_1SharedGroupExt-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:07:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_poc_sessions-v2_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_pocRules-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_pocusage-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_pocusage-V1_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/poc_sessionInvocationDescriptor-v2_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/PresenceSimple/</loc>
+  <lastmod>2024-11-25T21:38:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/prs_pidf_omapres-v1_0.xsd</loc>
+  <lastmod>2016-01-19T01:12:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/prs_pidf_omapres-V1_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/prs_presContent-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/prs_presrules-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/prs_pub_rules-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/prs_suppnotFilter-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/push-registration-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pxprof_common_types-v1_0.xsd</loc>
+  <lastmod>2016-12-08T13:59:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pxprof_mms_types-v1_0.xsd</loc>
+  <lastmod>2016-12-08T13:59:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pxprof_payment_types-v1_0.xsd</loc>
+  <lastmod>2016-12-08T13:59:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pxprof_sms_types-v1_0.xsd</loc>
+  <lastmod>2016-12-08T13:59:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/pxprof_terminallocation_types-v1_0.xsd</loc>
+  <lastmod>2016-12-08T13:59:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_addresslistmgt-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_audiocall-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_autho4api_url_prefixes_for_granted_resources-v1_0.xsd</loc>
+  <lastmod>2015-01-26T13:45:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_callnotification-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_common-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_common-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:07:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_devicecapabilities-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_dynnav-V1_0.xsd</loc>
+  <lastmod>2014-02-27T15:01:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_dynnav-V1_1.xsd</loc>
+  <lastmod>2015-08-10T08:43:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_messaging-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:09:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_messaging-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:09:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_navse-V1_0.xsd</loc>
+  <lastmod>2020-02-25T14:55:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_acrmanagement-v1_0.xsd</loc>
+  <lastmod>2015-12-09T12:43:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_addressbook-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_audiocall-v1_0.xsd</loc>
+  <lastmod>2020-03-24T13:15:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_botManagement-v1_0.xsd</loc>
+  <lastmod>2018-06-19T11:54:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_callnotification-v1_0.xsd</loc>
+  <lastmod>2020-03-24T13:15:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_capabilitydiscovery-v1_0.xsd</loc>
+  <lastmod>2018-06-19T11:54:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_chat-v1_0.xsd</loc>
+  <lastmod>2018-06-19T11:54:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_common-v1_0.xsd</loc>
+  <lastmod>2018-01-24T14:31:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_communicationpatterns-V1_0.xsd</loc>
+  <lastmod>2016-05-19T19:03:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_convergedaddressbook-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_customerprofile-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_devicecapabilities-v1_0.xsd</loc>
+  <lastmod>2015-12-11T14:51:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_devicecapabilities-v1_0_1.xsd</loc>
+  <lastmod>2015-12-11T14:53:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_filetransfer-v1_0.xsd</loc>
+  <lastmod>2015-12-09T13:19:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_imageshare-v1_0.xsd</loc>
+  <lastmod>2015-12-09T17:33:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_messagebroadcast-V1_0.xsd</loc>
+  <lastmod>2016-09-12T11:48:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_messaging-v1_0.xsd</loc>
+  <lastmod>2015-12-09T13:26:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_nms-v1_0.xsd</loc>
+  <lastmod>2019-06-25T08:40:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_notificationchannel-v1_0.xsd</loc>
+  <lastmod>2020-03-24T13:16:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_payment-v1_0.xsd</loc>
+  <lastmod>2013-10-22T16:04:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_presence-v1_0.xsd</loc>
+  <lastmod>2015-12-09T13:49:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_push-v1_0.xsd</loc>
+  <lastmod>2014-02-04T17:53:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_qos-v1_0.xsd</loc>
+  <lastmod>2014-12-08T10:57:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_roamingprovisioning-v1_0.xsd</loc>
+  <lastmod>2016-12-19T14:57:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_sms-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_terminallocation-v1_0.xsd</loc>
+  <lastmod>2013-10-22T16:04:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_terminallocation-v1_0_1.xsd</loc>
+  <lastmod>2015-11-16T11:44:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_terminalstatus-v1_0.xsd</loc>
+  <lastmod>2013-10-22T16:04:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_thirdpartycall-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_twinning-v1_0.xsd</loc>
+  <lastmod>2016-05-31T17:29:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_ucd-v1_0.xsd</loc>
+  <lastmod>2015-01-22T17:42:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_videoshare-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_webrtcsignaling-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_netapi_zonalpresence-v1_0.xsd</loc>
+  <lastmod>2018-08-06T11:07:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_payment-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:11:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_payment-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_presence-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_sms-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_sms-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:10:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_supm-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_terminallocation-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_terminallocation-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_terminalstatus-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/rest_thirdpartycall-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/reusable_resources_v1_0.xsd</loc>
+  <lastmod>2018-01-10T16:59:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/RULES/</loc>
+  <lastmod>2024-11-25T21:39:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/scab_comm_hist-v1_0.xsd</loc>
+  <lastmod>2017-08-30T08:46:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/scab_extensions-V1_0.xsd</loc>
+  <lastmod>2017-08-30T08:46:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/scab_user_preferences-v1_0.xsd</loc>
+  <lastmod>2017-08-30T08:46:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/SCE_LRM_V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:08:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/SCE_REL_DD-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/SCE_REL_EX-V1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/sce_rel_odd-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/SCE_ROAP-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/scidm_messages-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/seccf_gba-v1_1.xsd</loc>
+  <lastmod>2013-10-03T09:05:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/singlePhasePM.xsd</loc>
+  <lastmod>2016-03-22T09:19:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/spam_rep-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:07:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/STI/</loc>
+  <lastmod>2024-11-25T21:39:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/STI-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:11:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/supm_soap-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:06:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/UAPROF/</loc>
+  <lastmod>2024-11-25T21:39:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/UVE_messages-v1_0.xsd</loc>
+  <lastmod>2015-12-09T18:32:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/void-LWM2M_senml_units.xsd</loc>
+  <lastmod>2019-12-06T05:38:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/widl/</loc>
+  <lastmod>2024-11-25T21:39:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/XDM/</loc>
+  <lastmod>2024-11-25T21:39:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_2_1_extensions-V1_0.xsd</loc>
+  <lastmod>2017-02-13T10:12:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_2_2_extensions-V1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_access_permissions-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_access_permissions_list-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_alias_principals_list-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:58+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_commonPolicy-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:58+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_CommonPolicy-V1_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:08:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_extensions-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_forwarding_notification_list-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_modification_history.xsd</loc>
+  <lastmod>2017-02-13T10:11:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_palProfile-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:05:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_request_history-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_rsrclst_appusage-V1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_rsrclst_uriusage-V1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_search-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_uppDirectory-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_userProfile-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_xcapDirectory-v1_0.xsd</loc>
+  <lastmod>2013-10-03T09:10:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_xcapDirectory-V1_0_1.xsd</loc>
+  <lastmod>2013-10-03T09:07:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_xcapDirectory-v1_0_3.xsd</loc>
+  <lastmod>2017-02-13T10:11:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_xcapError-V1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_xdcp-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/xdm_xdmPreferences-v1_0.xsd</loc>
+  <lastmod>2017-02-13T10:11:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/profiles/XML%20Schema%20for%20Mobile%20Augmented%20Reality.xsd</loc>
+  <lastmod>2016-02-22T12:12:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/PEM_1_faults-v1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/PEM_1_faults_V1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/PEM_1_REQ-v1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/pem_1_REQ_V1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/PEM_1_RSP-v1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/pem_1_RSP_V1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/wsdl/supm_soap-v1_0.wsdl</loc>
+  <lastmod>2013-10-07T09:19:28+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/ila/ILA_System_Architecture_Release%201.0.pdf</loc>
+  <lastmod>2018-05-18T10:03:07+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/ila/ILA_Use_Case_Retail.pdf</loc>
+  <lastmod>2018-05-18T10:03:16+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/ila/ILA_Use_Case_transportation.pdf</loc>
+  <lastmod>2018-05-18T10:03:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/boilerplate.pdf</loc>
+  <lastmod>2013-09-23T05:14:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/lif-statement.pdf</loc>
+  <lastmod>2013-09-23T05:14:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omaspecworks/collaborate/affiliates/location-interoperability/</loc>
+  <lastmod>2024-11-22T17:27:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_CTXT_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:38+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_EME_LIA_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:39+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_EME_LIR_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_EMEREP_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:38+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_FUNC_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_GEM_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_GSM_NET_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:41+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_HDR_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_ID_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:42+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_LOC_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_QOP_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SHAPE_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SLIA_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SLIR_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SLIREP_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SLREP_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:46+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SVC_INIT_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_SVC_RESULT_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_TLRA_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_TLREP_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_TLRR_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_TLRSA_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/lif/MLP_TLRSR_300_DTD.txt</loc>
+  <lastmod>2013-09-23T05:14:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mgif/MGIF_Platform_Specification_v1.0.pdf</loc>
+  <lastmod>2013-09-23T05:15:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mgif/MGIF_Whitepaper_v1.0.pdf</loc>
+  <lastmod>2013-09-23T05:15:04+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omaspecworks/collaborate/affiliates/mobile-games-interoperability/</loc>
+  <lastmod>2024-11-22T17:27:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/gap.ppt</loc>
+  <lastmod>2013-09-23T05:15:16+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_001v2.doc</loc>
+  <lastmod>2013-09-23T05:15:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_001v2.pdf</loc>
+  <lastmod>2013-09-23T05:15:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_002v2.doc</loc>
+  <lastmod>2013-09-23T05:15:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_002v2.pdf</loc>
+  <lastmod>2013-09-23T05:15:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_003.doc</loc>
+  <lastmod>2013-09-23T05:15:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_003.pdf</loc>
+  <lastmod>2013-09-23T05:15:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_004v2.doc</loc>
+  <lastmod>2013-09-23T05:15:38+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_004v2.pdf</loc>
+  <lastmod>2013-09-23T05:15:35+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_006v2.doc</loc>
+  <lastmod>2013-09-23T05:16:05+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_006v2.pdf</loc>
+  <lastmod>2013-09-23T05:15:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_007.doc</loc>
+  <lastmod>2013-09-23T05:15:51+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/mwif/mtr_007.pdf</loc>
+  <lastmod>2013-09-23T05:15:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_devinf_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:08+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_http_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:09+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_metinf_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:10+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_obex_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_protocol_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:12+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_represent_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/changes_for_syncml_wsp_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:15+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/dsdmfest2/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/Errata_to_SyncML_Device_Information_DTD_Specification.pdf</loc>
+  <lastmod>2013-09-23T05:16:16+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/Errata_to_SyncML_Meta_Information_DTD_specification.pdf</loc>
+  <lastmod>2013-09-23T05:16:18+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/Errata_to_SyncML_OBEX_Binding.pdf</loc>
+  <lastmod>2013-09-23T05:16:18+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/Errata_to_SyncML_Representation_Protocol.pdf</loc>
+  <lastmod>2013-09-23T05:16:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/Errata_to_SyncML_Synchronization_Protocol.pdf</loc>
+  <lastmod>2013-09-23T05:16:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/Errata_to_SyncML_wsp_Binding.pdf</loc>
+  <lastmod>2013-09-23T05:16:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/extended_sys_client_proforma.pdf</loc>
+  <lastmod>2013-09-23T05:16:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/infobank_proforma_server_client_syncfest3.pdf</loc>
+  <lastmod>2013-09-23T05:16:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/interop_process.pdf</loc>
+  <lastmod>2013-09-23T05:16:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/introducing_syncml_29jan02_douglas_heintzman.pdf</loc>
+  <lastmod>2013-09-23T05:16:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/proforma.pdf</loc>
+  <lastmod>2013-09-23T05:16:29+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/sept2001_registration.htm</loc>
+  <lastmod>2013-09-23T05:16:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/sics_datasync101_syncfest7_server_solvix_server_v09.pdf</loc>
+  <lastmod>2013-09-23T05:16:32+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest1/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest2/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest3/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest5/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest5_dcmtec_client_sics.pdf</loc>
+  <lastmod>2013-09-23T05:16:35+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest6/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest7/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest8/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest9/</loc>
+  <lastmod>2024-11-25T21:41:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncfest_nda.pdf</loc>
+  <lastmod>2013-09-23T05:16:38+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_compliant_products.html</loc>
+  <lastmod>2013-09-23T05:16:43+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_compliant_products_missing%20files.html</loc>
+  <lastmod>2013-09-23T05:16:44+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_devinf_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:16:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_devinf_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:16:49+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_devinf_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:16:50+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_devinf_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_devman_business_cases_whppr.pdf</loc>
+  <lastmod>2013-09-23T05:16:54+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_boot_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:56+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_conreqs_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:57+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_notification_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:16:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_protocol_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_represent_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:01+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_sec_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:03+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_std_obj_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:04+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_dm_tnd_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:05+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_http_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:17:07+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_http_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:17:07+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_http_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:17:09+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_http_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:10+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_ics_v10_20011102.doc</loc>
+  <lastmod>2013-09-23T05:17:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_ip_agreement.pdf</loc>
+  <lastmod>2013-09-23T05:17:15+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_ip_declarations.pdf</loc>
+  <lastmod>2013-09-23T05:17:16+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_ipr_claims.pdf</loc>
+  <lastmod>2013-09-23T05:17:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_ipr_declarations.pdf</loc>
+  <lastmod>2013-09-23T05:17:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_ipr_policy.pdf</loc>
+  <lastmod>2013-09-23T05:17:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_metinf_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:17:18+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_metinf_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:17:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_metinf_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:17:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_metinf_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_obex_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:17:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_obex_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:17:26+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_obex_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:17:27+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_obex_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_protocol_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:17:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_protocol_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:17:34+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_protocol_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:17:37+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_represent_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:18:08+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_represent_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:17:47+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_represent_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:17:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_represent_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:17:59+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_roadmap_30jan02_teemu_toroi.pdf</loc>
+  <lastmod>2013-09-23T05:18:02+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_scts_la.pdf</loc>
+  <lastmod>2013-09-23T05:18:04+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_summit_faxreg.pdf</loc>
+  <lastmod>2013-09-23T05:18:05+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_sync_protocol_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:18:08+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_sync_represent_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:18:13+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_test_cases_v10_20011102.doc</loc>
+  <lastmod>2013-09-23T05:18:11+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_whitepaper.html</loc>
+  <lastmod>2013-09-23T05:18:14+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_wsp_v101_20010530.pdf</loc>
+  <lastmod>2013-09-23T05:18:15+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_wsp_v101_20010615.pdf</loc>
+  <lastmod>2013-09-23T05:18:17+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_wsp_v10_20001207.pdf</loc>
+  <lastmod>2013-09-23T05:18:17+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncml_wsp_v11_20020215.pdf</loc>
+  <lastmod>2013-09-23T05:18:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/syncmldm_28jan02_james_jennings.pdf</loc>
+  <lastmod>2013-09-23T05:16:40+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/omaspecworks/collaborate/affiliates/syncml/</loc>
+  <lastmod>2024-11-22T17:27:23+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/test_cases.pdf</loc>
+  <lastmod>2013-09-23T05:18:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/test_suite.pdf</loc>
+  <lastmod>2013-09-23T05:18:22+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/testing_process.pdf</loc>
+  <lastmod>2013-09-23T05:18:20+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/v1-0-1release_notes.pdf</loc>
+  <lastmod>2013-09-23T05:18:25+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/syncml/whitepaper.pdf</loc>
+  <lastmod>2013-09-23T05:18:24+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/wap/OMA-WAP-211_105-WAPCert-SIN-20020520-a.pdf</loc>
+  <lastmod>2013-09-23T05:18:28+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/wap/OMA-WAP-217_105-WPKI-SIN-20020816-a.pdf</loc>
+  <lastmod>2013-09-23T05:18:30+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/wap/OMA-WAP-224_002-WTP-SIN-20020827-a.PDF</loc>
+  <lastmod>2013-09-23T05:18:31+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/tech/affiliates/wap/OMA-WAP-260_100-WIM-SIN-20010725-a.pdf</loc>
+  <lastmod>2013-09-23T05:18:32+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+
+
+</urlset>

--- a/public/test_events-sitemap.xml
+++ b/public/test_events-sitemap.xml
@@ -1,0 +1,1468 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/__sitemap__/style.xsl"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-1/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-19/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-2/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20_5/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-21/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-22/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-23/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-25/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-26/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-28/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-31/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-4/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-5/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-6/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-7/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-8/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9.5/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-29/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-30/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-38/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-39/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-1/OMA-EnablerTestReport-TestFest-1a-Nov02-DSDM-11-20021128.pdf</loc>
+  <lastmod>2013-09-20T12:23:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-1/OMA-EnablerTestReport-TestFest-1b-Dec02-IMPS-10-20021227.pdf</loc>
+  <lastmod>2013-09-20T12:23:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-1/OMA-EnablerTestReport-TestFest1-Feb03-DS101-DS111-DM11-20030206.pdf</loc>
+  <lastmod>2013-09-20T12:23:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-BROWSING-2x-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:24:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-DataSync-112-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:23:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-DataSyncv1.2-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:23:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-DevMan-112-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:23:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-DRM-20-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:23:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-MMS-12-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:23:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-10/OMA-EnablerTestReport-OMATestFest10-Sept2005-PoC-10-20050926.pdf</loc>
+  <lastmod>2013-09-20T12:24:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-DataSync-1.1.2-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-DataSyncv1.2-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-DevMan-1.1.2-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-DRM-2.0-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-PoC-1.0-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-PRS-1.0-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-11/OMA-EnablerTestReport-TestFest-11-Nov2005-XDM-1.0-20051124.pdf</loc>
+  <lastmod>2013-09-20T12:25:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-DataSyncv1.2-20060203.pdf</loc>
+  <lastmod>2013-09-20T12:26:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-DevMan-112-20060203.pdf</loc>
+  <lastmod>2013-09-20T12:26:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-DRM-10-20060207.pdf</loc>
+  <lastmod>2013-09-20T12:26:58+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-DRM-20-20060206.pdf</loc>
+  <lastmod>2013-09-20T12:27:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-PoC-10-20060209.pdf</loc>
+  <lastmod>2013-09-20T12:27:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-PRS-10-20060203.pdf</loc>
+  <lastmod>2013-09-20T12:27:13+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-12/OMA-EnablerTestReport-TestFest-12-Jan2006-XDM-10-20060204.pdf</loc>
+  <lastmod>2013-09-20T12:27:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/OMA-EnablerTestReport-TestFest-14-Mar2006-Browsing-21_22-20060405.pdf</loc>
+  <lastmod>2013-09-20T12:28:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/OMA-EnablerTestReport-TestFest-14-Mar2006-DRM-20-20060406.pdf</loc>
+  <lastmod>2013-09-20T12:28:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/OMA-EnablerTestReport-TestFest-14-Mar2006-DS-12-20060407.pdf</loc>
+  <lastmod>2013-09-20T12:28:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/OMA-EnablerTestReport-TestFest-14-Mar2006-PoC-10-20060404.pdf</loc>
+  <lastmod>2013-09-20T12:28:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/OMA-EnablerTestReport-TestFest-14-Mar2006-PRS-10-20060406.pdf</loc>
+  <lastmod>2013-09-20T12:28:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-14/OMA-EnablerTestReport-TestFest-14-Mar2006-XDM-10-20060404.pdf</loc>
+  <lastmod>2013-09-20T12:28:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-Browsing-21_22-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:30:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-DM-12-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:29:57+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-DRM-20-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:30:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-EMN-10-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:30:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-IMPS-13-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:30:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-PoC-10-20060715.pdf</loc>
+  <lastmod>2013-09-20T12:30:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-PRS-10-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:30:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-SUPL-10-20060713.pdf</loc>
+  <lastmod>2013-09-20T12:30:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-15/OMA-EnablerTestReport-TestFest-15-Jun2006-XDM-10-20060707.pdf</loc>
+  <lastmod>2013-09-20T12:30:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-DM-12-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-DRM-20-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-DS-12-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-FUMO-10-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-IMPS-13-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-PoC-10-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-PRS-10-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-SUPL-10-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-16/OMA-EnablerTestReport-TestFest-16-Sep2006-XDM-10-20060922.pdf</loc>
+  <lastmod>2013-09-20T12:31:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/OMA-EnablerTestReport-TestFest-17-Dec2006-DM-12-20061215.pdf</loc>
+  <lastmod>2013-09-20T12:32:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/OMA-EnablerTestReport-TestFest-17-Dec2006-FUMO-10-20061215.pdf</loc>
+  <lastmod>2013-09-20T12:32:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/OMA-EnablerTestReport-TestFest-17-Dec2006-IMPS-13-20061214.pdf</loc>
+  <lastmod>2013-09-20T12:32:48+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/OMA-EnablerTestReport-TestFest-17-Dec2006-PoC-10-20061215.pdf</loc>
+  <lastmod>2013-09-20T12:32:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/OMA-EnablerTestReport-TestFest-17-Dec2006-PRS-10-20061215.pdf</loc>
+  <lastmod>2013-09-20T12:32:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-17/OMA-EnablerTestReport-TestFest-17-Dec2006-XDM-10-20061215.pdf</loc>
+  <lastmod>2013-09-20T12:32:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-BRW-V2_3-20070309.pdf</loc>
+  <lastmod>2013-09-20T12:33:26+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-DRM-V2_0-20070309.pdf</loc>
+  <lastmod>2013-09-20T12:33:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-IMPS-V1_3-20070309.pdf</loc>
+  <lastmod>2013-09-20T12:33:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-PoC-V1_0-20070309.pdf</loc>
+  <lastmod>2013-09-20T12:33:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-PRS-V1_0-20070309.pdf</loc>
+  <lastmod>2013-09-20T12:33:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-SUPL-V1_0-20070312.pdf</loc>
+  <lastmod>2013-09-20T12:33:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-18/OMA-EnablerTestReport-TestFest-18-Mar2007-XDM-V1_0-20070309.pdf</loc>
+  <lastmod>2013-09-20T12:33:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-19/OMA-EnablerTestReport-TestFest-19-May2007-DM-12-20070601.pdf</loc>
+  <lastmod>2013-09-20T12:36:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-19/OMA-EnablerTestReport-TestFest-19-May2007-FUMO-10-20070601.pdf</loc>
+  <lastmod>2013-09-20T12:36:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-19/OMA-EnablerTestReport-TestFest-19-May2007-IMPS-13-20070601.pdf</loc>
+  <lastmod>2013-09-20T12:36:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-19/OMA-EnablerTestReport-TestFest-19-May2007-PRS-10-20070601.pdf</loc>
+  <lastmod>2013-09-20T12:36:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-19/OMA-EnablerTestReport-TestFest-19-May2007-SUPL-V1_0-20070604.pdf</loc>
+  <lastmod>2013-09-20T12:36:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-2/OMA-EnablerTestReport-TestFest2-Mar03-IMPS-11-20030401.pdf</loc>
+  <lastmod>2013-09-20T12:36:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20/OMA-EnablerTestReport-TestFest-20-Sep2007-DM-12-20070921.pdf</loc>
+  <lastmod>2013-09-20T12:40:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20/OMA-EnablerTestReport-TestFest-20-Sep2007-DRM-20-20070921.pdf</loc>
+  <lastmod>2013-09-20T12:40:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20/OMA-EnablerTestReport-TestFest-20-Sep2007-DRM-21-20070921.pdf</loc>
+  <lastmod>2013-09-20T12:40:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20/OMA-EnablerTestReport-TestFest-20-Sep2007-FUMO-10-20070921.pdf</loc>
+  <lastmod>2013-09-20T12:40:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20/OMA-EnablerTestReport-TestFest-20-Sep2007-IMPS-13-20070921.pdf</loc>
+  <lastmod>2013-09-20T12:40:52+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-20_5/TF-20_5_OMA-EnablerTestReport-TestFest-20_5-Sep2007-BCAST-10-20071005.pdf</loc>
+  <lastmod>2013-09-20T12:42:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-21/OMA-EnablerTestReport-TestFest-21-Nov2007-BCAST-10-20071123.pdf</loc>
+  <lastmod>2013-09-20T12:42:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-21/OMA-EnablerTestReport-TestFest-21-Nov2007-PRS-101-20071123.pdf</loc>
+  <lastmod>2013-09-20T12:42:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-21/OMA-EnablerTestReport-TestFest-21-Nov2007-SUPL-10-20071123.pdf</loc>
+  <lastmod>2013-09-20T12:42:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-22/OMA-EnablerTestReport-TestFest-22-Jan2008-BCAST-10-20080201.pdf</loc>
+  <lastmod>2013-09-20T12:42:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-22/OMA-EnablerTestReport-TestFest-22-Jan2008-DM-12-20080201.pdf</loc>
+  <lastmod>2013-09-20T12:42:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-22/OMA-EnablerTestReport-TestFest-22-Jan2008-DRM-20-20080201.pdf</loc>
+  <lastmod>2013-09-20T12:42:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-22/OMA-EnablerTestReport-TestFest-22-Jan2008-DRM-21-20080201.pdf</loc>
+  <lastmod>2013-09-20T12:42:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-22/OMA-EnablerTestReport-TestFest-22-Jan2008-SCWS-10-20080201.pdf</loc>
+  <lastmod>2013-09-20T12:42:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-23/OMA-EnablerTestReport-TestFest-23-Mar2008-BCAST-10-20080411.pdf</loc>
+  <lastmod>2013-09-20T12:43:05+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-25/OMA-EnablerTestReport-TestFest-25-Sep2008-BCAST-10-20081022.pdf</loc>
+  <lastmod>2013-09-20T12:42:58+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-25/OMA-EnablerTestReport-TestFest-25-Sep2008-SRM-10-20081022.pdf</loc>
+  <lastmod>2013-09-20T12:43:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-26/OMA-EnablerTestReport-TestFest-26-Nov2008-DM-12-20081201.pdf</loc>
+  <lastmod>2013-09-20T12:22:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-26/OMA-EnablerTestReport-TestFest-26-Nov2008-DS-121-20081201.pdf</loc>
+  <lastmod>2013-09-20T12:22:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-26/OMA-EnablerTestReport-TestFest-26-Nov2008-FUMO-10-20081201.pdf</loc>
+  <lastmod>2013-09-20T12:22:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-26/OMA-EnablerTestReport-TestFest-26-Nov2008-SRM-10-20081201.pdf</loc>
+  <lastmod>2013-09-20T12:22:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-28/OMA-EnablerTestReport-TestFest-28-May2009-DM-12-20090529-old.pdf</loc>
+  <lastmod>2013-09-20T12:43:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-28/OMA-EnablerTestReport-TestFest-28-May2009-DM-12-20090723.pdf</loc>
+  <lastmod>2013-09-20T12:43:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/OMA-EnablerTestReport-TestFest3-Jun03-DataSync-101-20030709.pdf</loc>
+  <lastmod>2013-09-20T12:43:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/OMA-EnablerTestReport-TestFest3-Jun03-DataSync-111-20030709.pdf</loc>
+  <lastmod>2013-09-20T12:43:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/OMA-EnablerTestReport-TestFest3-Jun03-DevMan-111-20030709.pdf</loc>
+  <lastmod>2013-09-20T12:43:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/OMA-EnablerTestReport-TestFest3-Jun03-IMPS-CSP11-20030709.pdf</loc>
+  <lastmod>2013-09-20T12:43:35+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/OMA-EnablerTestReport-TestFest3-Jun03-IMPS-SSP11-20030709.pdf</loc>
+  <lastmod>2013-09-20T12:43:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-3/OMA-EnablerTestReport-TestFest3-Jun03-MMS-11-20030709.pdf</loc>
+  <lastmod>2013-09-20T12:43:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-31/TestFest%20Summary%20Document.pdf</loc>
+  <lastmod>2022-06-09T10:17:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/Altiux_Innovations_Client_Results_Post.pdf</loc>
+  <lastmod>2022-06-16T15:13:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/Altiux_Innovations_Server_Results_Post.pdf</loc>
+  <lastmod>2022-06-16T15:14:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/AVSystem_Client_Results_Post.pdf</loc>
+  <lastmod>2022-06-16T16:00:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/AVSystem_Server_Results_Post.pdf</loc>
+  <lastmod>2022-06-16T16:01:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/Gemalto_Client_Results_Post.pdf</loc>
+  <lastmod>2022-06-20T15:18:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/Gemalto_Server_Results_Post.pdf</loc>
+  <lastmod>2022-06-20T15:19:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-32/Jan.2016.TestFest.Summary.Document.pdf</loc>
+  <lastmod>2022-06-08T16:00:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/AVSystem-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-16T15:57:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/AVSystem-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-16T15:58:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/Ericsson-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T14:29:44+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/IOTEROP-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T15:53:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/IOTEROP-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T15:52:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/MDS-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-21T10:19:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-33/OMA-TestFest-Results-Summary-Singapore.pdf</loc>
+  <lastmod>2022-06-08T15:56:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/ARM-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-16T15:21:09+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/ARM-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-16T15:23:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/AVSystem-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-16T15:53:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/AVSystem-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-16T15:55:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/Centero-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-17T10:55:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/Ericsson-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T14:26:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/Gemalto-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T15:17:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/Huawei-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T15:32:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/IoTerop-Results-Post.pdf</loc>
+  <lastmod>2022-06-20T15:50:31+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/MDS-Results-Post.pdf</loc>
+  <lastmod>2022-06-21T10:15:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/SmithMicro-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-21T10:43:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/SmithMicro-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-21T10:44:39+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/Telit-Client-Results-Post.pdf</loc>
+  <lastmod>2022-06-21T10:48:36+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/Telit-Server-Results-Post.pdf</loc>
+  <lastmod>2022-06-21T10:49:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-34/TestFest-Summary-Document.pdf</loc>
+  <lastmod>2022-06-08T15:52:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov-ARM-Posted_Results.pdf</loc>
+  <lastmod>2022-06-16T15:19:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Altair_Semiconductor-Results_Posted.pdf</loc>
+  <lastmod>2022-06-16T15:09:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_AVSystem-Server-Posted-Results.pdf</loc>
+  <lastmod>2022-06-16T15:51:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_AVSystems._Client_Posted_Results.pdf</loc>
+  <lastmod>2022-06-16T15:49:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Ericsson_Server_Posted_Results.pdf</loc>
+  <lastmod>2022-06-20T14:24:42+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_ETRI_Client_Posted_Results.pdf</loc>
+  <lastmod>2022-06-20T15:06:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Gamalto-Server-Results-Posted.pdf</loc>
+  <lastmod>2022-06-20T15:15:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Gemalto_Client_Posted_Results.pdf</loc>
+  <lastmod>2022-06-20T15:13:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_INTEROP-Client-Posted-Results.pdf</loc>
+  <lastmod>2022-06-20T15:47:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_IoTerop-Server-Posted-Results.pdf</loc>
+  <lastmod>2022-06-20T15:49:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_KONAS-Client-Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:10:11+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Konas_Server_Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:11:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Smith_Micro_Client_Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:39:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Smith_Micro_Server-Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:40:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Telit-Client_Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:46:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw-2017-Nov_Telit-Server-Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:47:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw_2017_Nov-Cumulocity-Server-Posted-Results.pdf</loc>
+  <lastmod>2022-06-20T14:16:49+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw_2017_Nov-Friendly_Technologies_Client_Posted_Results.pdf</loc>
+  <lastmod>2022-06-20T15:07:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw_2017_Nov-Friendly_Technologies_Server_Posted_Results.pdf</loc>
+  <lastmod>2022-06-20T15:10:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw_2017_Nov_Nokia._Server_Posted_Results.pdf</loc>
+  <lastmod>2022-06-21T10:37:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-35/Warsaw_Nov_2017_All_Test_Results.pdf</loc>
+  <lastmod>2022-06-08T15:47:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Korea_July_2018_All_Test_Results.pdf</loc>
+  <lastmod>2022-06-08T15:40:24+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Ahnlab-Client_Results_Posted.pdf</loc>
+  <lastmod>2022-06-16T15:03:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-ARM-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-16T15:17:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-AVSystems-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-16T15:47:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Ericsson-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-20T14:23:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Gemalto-Client_Results_Posted.pdf</loc>
+  <lastmod>2022-06-20T15:12:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Hancom-Client_Results_Posted.pdf</loc>
+  <lastmod>2022-06-20T15:30:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Hancom-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-20T15:31:38+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-III-Client_Results_Posted.pdf</loc>
+  <lastmod>2022-06-16T14:56:01+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-III-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-16T14:58:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-IOTerop-Client_Results_Posted.pdf</loc>
+  <lastmod>2022-06-20T15:45:06+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Konas-Client_Results_Posted.pdf</loc>
+  <lastmod>2022-06-21T10:00:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Konas-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-21T10:08:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Kookmin.University-Server_Results_Posted.pdf</loc>
+  <lastmod>2022-06-21T10:13:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-36/Seoul-2018-Jul-Nokia-Servewr_Results_Posted.pdf</loc>
+  <lastmod>2022-06-21T10:36:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/Altair.Semiconductors.V1.1.-.Client.pdf</loc>
+  <lastmod>2022-06-16T15:07:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/AVSystem.-.1.0.Server.Results.pdf</loc>
+  <lastmod>2022-06-16T15:33:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/AVSystem.1.1.Server.ALL.Results.pdf</loc>
+  <lastmod>2022-06-16T15:41:14+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/AVSystem.v1.0.Client.pdf</loc>
+  <lastmod>2022-06-16T15:43:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/AVSystem.v1.1.Client.pdf</loc>
+  <lastmod>2022-06-16T15:44:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/Ericsson.v1.1.Server.Results.pdf</loc>
+  <lastmod>2022-06-20T14:20:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/iii.-.1.0.Client.pdf</loc>
+  <lastmod>2022-06-09T14:54:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/iii.-.1.1.Client.pdf</loc>
+  <lastmod>2022-06-16T14:48:45+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/iii.v1.0.Server.Results.pdf</loc>
+  <lastmod>2022-06-16T14:46:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/III.v1.1.Server.Results.pdf</loc>
+  <lastmod>2022-06-16T14:52:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/IoTerop.Server.1.1.Results.pdf</loc>
+  <lastmod>2022-06-20T15:43:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/IoTerop.v1.1.Client.pdf</loc>
+  <lastmod>2022-06-20T15:41:46+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/Korea_Oct_2019_v1_0_Consolidated_Test_Results.pdf</loc>
+  <lastmod>2022-06-08T15:35:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/Korea_Oct_2019_v1_1_Consolidated_Test_Results.pdf</loc>
+  <lastmod>2022-06-08T15:35:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-37/Nokia.v1.1.Server.Results.pdf</loc>
+  <lastmod>2022-06-21T10:34:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-4/OMA-EnablerTestReport-TestFes4-tNov03-MMS-11-20031127.pdf</loc>
+  <lastmod>2013-09-20T12:44:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-4/OMA-EnablerTestReport-TestFest4-Nov03-DL-11-20031128.pdf</loc>
+  <lastmod>2013-09-20T12:43:53+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-4/OMA-EnablerTestReport-TestFest4-Nov03-DRM-11-20031125.pdf</loc>
+  <lastmod>2013-09-20T12:44:00+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-4/OMA-EnablerTestReport-TestFest4-Nov03-IMPS-CSP11-20031128.pdf</loc>
+  <lastmod>2013-09-20T12:44:03+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-4/OMA-EnablerTestReport-TestFest4-Nov03-IMPS-SSP11-20031128.pdf</loc>
+  <lastmod>2013-09-20T12:44:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-5/OMA-EnablerTestReport-TestFest5-Mar04-DataSync-112-20040323.pdf</loc>
+  <lastmod>2013-09-20T12:44:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-5/OMA-EnablerTestReport-TestFest5-Mar04-DRM-11-20040319.pdf</loc>
+  <lastmod>2013-09-20T12:44:22+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-5/OMA-EnablerTestReport-TestFest5-Mar04-IMPS-CSP12-20040325.pdf</loc>
+  <lastmod>2013-09-20T12:44:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-5/OMA-EnablerTestReport-TestFest5-Mar04-IMPS-SSP12-20040326.pdf</loc>
+  <lastmod>2013-09-20T12:44:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-5/OMA-EnablerTestReport-TestFest5-Mar04-MMS-11-20040323.pdf</loc>
+  <lastmod>2013-09-20T12:44:32+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-6/OMA-EnablerTestReport-TestFest6-May04-DevMan-112-20040604.pdf</loc>
+  <lastmod>2013-09-20T12:44:50+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-6/OMA-EnablerTestReport-TestFest6-May04-DRM-01-20040604.pdf</loc>
+  <lastmod>2013-09-20T12:44:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-6/OMA-EnablerTestReport-TestFest6-May04-MMS-12-20040604.pdf</loc>
+  <lastmod>2013-09-20T12:44:54+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-7/OMA-EnablerTestReport-TestFest7-Oct04-CP-11-20041029.pdf</loc>
+  <lastmod>2013-09-20T12:45:15+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-7/OMA-EnablerTestReport-TestFest7-Oct04-DevMan-112-20041029.pdf</loc>
+  <lastmod>2013-09-20T12:45:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-7/OMA-EnablerTestReport-TestFest7-Oct04-DRM-10-20041029.pdf</loc>
+  <lastmod>2013-09-20T12:45:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-7/OMA-EnablerTestReport-TestFest7-Oct04-IMPS-CSP12-20041029.pdf</loc>
+  <lastmod>2013-09-20T12:45:23+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-7/OMA-EnablerTestReport-TestFest7-Oct04-MMS-12-20041029.pdf</loc>
+  <lastmod>2013-09-20T12:45:27+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-8/OMA-EnablerTestReport-OMATestFest-%20Jan2005-DataSync-112-20050128.pdf</loc>
+  <lastmod>2013-09-20T12:45:41+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-8/OMA-EnablerTestReport-OMATestFest-%20Jan2005-DataSync-12-20050128.pdf</loc>
+  <lastmod>2013-09-20T12:45:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-8/OMA-EnablerTestReport-OMATestFest-Jan2005-DevMan-112-20050128.pdf</loc>
+  <lastmod>2013-09-20T12:45:40+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-8/OMA-EnablerTestReport-OMATestFest-Jan2005-IMPS-CSP12-20050128.pdf</loc>
+  <lastmod>2013-09-20T12:45:43+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-8/OMA-EnablerTestReport-OMATestFest-Jan2005-MMS-12-20050128.pdf</loc>
+  <lastmod>2013-09-20T12:45:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-BROWSING-2x-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:04+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-CP-11-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-DataSync-112-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:17+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-DataSyncv1.2-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:12+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-DevMan-112-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-DRM-10-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:34+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-DRM-20-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:25+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-IMPS-CSP12-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:29+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-MMS-12-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9/OMA-EnablerTestReport-TestFest9-May2005-PoC-10-20050527.pdf</loc>
+  <lastmod>2013-09-20T12:46:37+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/TF-9.5/OMA-EnablerTestReport-TestFest-9.5-Jul05-PoC-v1.0-20050805.pdf</loc>
+  <lastmod>2013-09-20T12:48:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Aetheros-Client-LwM2M-v1_0-Test-Results.pdf</loc>
+  <lastmod>2024-01-25T19:17:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Aetheros-Client-LwM2M-v1_1-Test-Results.pdf</loc>
+  <lastmod>2024-01-25T19:17:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Aetheros-Server-LwM2M-v1_0-Test-Results.pdf</loc>
+  <lastmod>2024-01-25T19:17:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Aetheros-Server-LwM2M-v1_1-Test-Results.pdf</loc>
+  <lastmod>2024-01-25T19:17:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Bulk-Tainer-Telematics-Client-LwM2M-v1_1-Test-Results.pdf</loc>
+  <lastmod>2024-01-25T19:17:18+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Cumulocity-Server-LwM2M-v1_0-Test-Results.pdf</loc>
+  <lastmod>2024-02-15T19:23:51+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Cumulocity-Server-LwM2M-v1_1-Test-Results.pdf</loc>
+  <lastmod>2024-02-15T19:23:55+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Event-Conglomerated-Test-Results-LwM2M-v1_0.pdf</loc>
+  <lastmod>2024-01-25T19:17:07+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Event-Conglomerated-Test-Results-LwM2M-v1_1.pdf</loc>
+  <lastmod>2024-01-25T19:17:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VSVE-40/SVE-40_15-21-Nov-2023_Event-Conglomerated-Test-Results-LwM2M-v1_2.pdf</loc>
+  <lastmod>2024-01-25T19:17:08+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-29/OMA-EnablerTestReport-VirtualTest-01-Sep2009-SCOMO-10-20090914.pdf</loc>
+  <lastmod>2013-09-20T12:50:19+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-29/OMA-EnablerTestReport-VirtualTest-01-Sep2009-SCOMO-10-20090917.pdf</loc>
+  <lastmod>2013-09-20T12:49:47+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-30/OMA-EnablerTestReport-VirtualTestEvent-02-Sep2010-DS-121-20101011.pdf</loc>
+  <lastmod>2013-09-20T12:50:02+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-38/AVSystem_1.1_Client.pdf</loc>
+  <lastmod>2022-06-16T15:31:56+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-38/IoTerop_1.1_Client_Results.pdf</loc>
+  <lastmod>2022-06-20T15:37:10+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-38/IoTerop_1.1_Server_Results.pdf</loc>
+  <lastmod>2022-06-20T15:39:33+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-38/Virtual_Apr_2020_All_Test_Results.pdf</loc>
+  <lastmod>2022-06-08T15:30:30+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-39/AVSystem.consolidated.Client.Results.pdf</loc>
+  <lastmod>2022-06-16T15:27:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-39/AVSystem.consolidated.Server.Results.pdf</loc>
+  <lastmod>2022-06-16T15:28:59+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-39/Mar_2021_VTF_Summary_and_Results.pdf</loc>
+  <lastmod>2022-06-08T14:48:21+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-39/Mar_2021_VTF_Summary_and_Results_v1.0.pdf</loc>
+  <lastmod>2022-06-08T14:48:20+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/VTF-39/Virtual-TestFest-Mar-2021-Pardox-Engineering_v1.1-Client%20Results.pdf</loc>
+  <lastmod>2023-07-24T10:57:16+00:00</lastmod>
+  <priority>0.64</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.0/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.1/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.2/</loc>
+  <lastmod>2024-11-25T21:48:48+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_Event%20Conglomerated-Test_Results-LwM2M%20v1_1.pdf</loc>
+  <lastmod>2024-08-06T16:42:45+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_Event%20Conglomerated-Test_Results-LwM2M%20v1_2.pdf</loc>
+  <lastmod>2024-08-06T16:43:55+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_Event-Conglomerated-Test_Results_LwM2M%20v1_0.pdf</loc>
+  <lastmod>2024-08-06T17:07:52+00:00</lastmod>
+  <priority>0.51</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.0/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_AvSystem-Client-Test_Results-LwM2M%20v1_0.pdf</loc>
+  <lastmod>2024-08-07T07:34:15+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.0/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_IoTerop-Server-Test_Results-LwM2M%20v1_0.pdf</loc>
+  <lastmod>2024-08-07T07:34:14+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.1/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_6D%20Technologies-Server-Test_Results-LwM2M%20v1_1.pdf</loc>
+  <lastmod>2024-08-07T07:35:40+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.1/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_AVSystem-Client-Test_Results-LwM2M%20v1_1.pdf</loc>
+  <lastmod>2024-08-07T07:35:39+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.1/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_Cumolocity-Server-Test_Results-LwM2M%20v1_1.pdf</loc>
+  <lastmod>2024-08-07T07:35:41+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.1/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_IoTerop-Server-Test_Results-LwM2M%20v1_1.pdf</loc>
+  <lastmod>2024-08-07T07:35:42+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.1/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_Itron-Client-Test_Results-LwM2M%20v1_1.pdf</loc>
+  <lastmod>2024-08-07T07:35:42+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.2/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_6D%20Technologies-Server-Test_Results-LwM2M%20v1_2.pdf</loc>
+  <lastmod>2024-08-07T07:36:30+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.2/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_AvSystem_Client-Test_Results-LwM2M%20v1_2.pdf</loc>
+  <lastmod>2024-08-07T07:36:32+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+<url>
+  <loc>https://www.openmobilealliance.org/test_events/SVE-41/Test%20Results/LwM2M%20v1.2/OMA-SVE-41%20(Raleigh,USA),%2010-13%20June%202024_IoTerop_Server_Test_Results-LwM2M%20v1_2.pdf</loc>
+  <lastmod>2024-08-07T07:36:32+00:00</lastmod>
+  <priority>0.41</priority>
+</url>
+
+
+</urlset>


### PR DESCRIPTION
Add additional sitemaps to enable better site indexing

Used [XML-Sitemaps.com](https://www.xml-sitemaps.com/) to create additional `sitemaps`.

Afterwards add the node so the new generated ones share same `CSS`.

Address #407 .

It should be validated in Google Analytic if the additional `sitemap` files helps in indexing the resources in question.