### PR TITLE
fix: icons bundle set to remote

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -33,8 +33,12 @@ export default defineNuxtConfig({
     }
   },
 
-  ui: {
-    icons: ["heroicons-solid", "fa6-brands", "devicon", "icons8"],
+  // ui: {
+  //   icons: ["heroicons-solid", "fa6-brands", "devicon", "icons8"],
+  // },
+
+  icon: {
+    serverBundle: 'remote',
   },
 
   gtm: {


### PR DESCRIPTION
Resolving issue [#197 from docs](https://github.com/standards-hub/docs/issues/197)