### PR TITLE
[ADMIN] bulk reservation objects 36000-36049 range for IOX GmbH

### DIFF
--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -275,4 +275,8 @@
         "ObjectIDRange": "35950 - 35999", 
         "CompanyName": "Utonomy"
     }
+    {
+        "ObjectIDRange": "36000 - 36049", 
+        "CompanyName": "IOX GmbH"
+    }
 ]

--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -274,7 +274,7 @@
     {
         "ObjectIDRange": "35950 - 35999", 
         "CompanyName": "Utonomy"
-    }
+    },
     {
         "ObjectIDRange": "36000 - 36049", 
         "CompanyName": "IOX GmbH"


### PR DESCRIPTION
A new bulk object reservation for IOX GmbH is available for 36000-36049, as requested per [Helpdesk Issue-8132](https://helpdesk.openmobilealliance.org/browse/OPEN-8132).