### PR TITLE
Icons Render Issue Fix

### DIFF
--- a/components/content/sh-alert.vue
+++ b/components/content/sh-alert.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="alert" :class="[ui.wrapper, alert]">
         <div :class="ui.base">
-            <UIcon :class="['size-7']" :name="icon" dynamic></UIcon>
+            <UIcon :class="['size-7', iconColor]" :name="icon" dynamic></UIcon>
         </div>
         <ContentSlot :use="$slots.default" unwrap="" />
     </div>
@@ -59,6 +59,23 @@ const icon = computed(() => {
             break;
         default: // info
             return config.icon.info;
+            break;
+    }
+});
+
+const iconColor = computed(() => {
+    switch (props.typeAlert) {
+        case "success":
+            return config.icon.color.success;
+            break;
+        case "warning":
+            return config.icon.color.warning;
+            break;
+        case "danger":
+            return config.icon.color.danger;
+            break;
+        default: // info
+            return config.icon.color.info;
             break;
     }
 });

--- a/ui.config/sh-alert.ts
+++ b/ui.config/sh-alert.ts
@@ -1,6 +1,6 @@
 export default {
-  wrapper: "flex items-center space-x-1 mt-4 mb-4 shadow-md rounded-xl",
-  base: "flex mx-2 p-1 mr-3",
+  wrapper: "flex items-center space-x-1 mt-4 mb-4 shadow-md rounded-xl text-xl",
+  base: "flex mx-2 p-1",
   alert: {
     success: 'bg-[#F0FFF4] dark:bg-[#22543D] text-[#2F855A] dark:text-[#9AE6B4] relative border-l-4 border-[#68D391] dark:border-[#2F855A]',
     warning: 'bg-[#FFFAF0] dark:bg-[#744210] text-[#C05621] dark:text-[#FBD38D] relative border-l-4 border-[#F6AD55] dark:border-[#B7791F]',
@@ -8,10 +8,16 @@ export default {
     info: 'bg-[#EBF8FF] dark:bg-[#2A4365] text-[#2B6CB0] dark:text-[#90CDF4] relative border-l-4 border-[#63B3ED] dark:border-[#2B6CB0]',
   },
   icon: {
-    success: 'text-[#68D391] dark:text-[#68D391] i-heroicons-check-circle',
-    warning: 'text-[#F6AD55] dark:text-[#F6AD55] i-heroicons-exclamation-circle',
-    danger: 'text-[#FC8181] dark:text-[#FC8181] i-heroicons-x-circle',
-    info: 'text-[#63B3ED] dark:text-[#63B3ED] i-heroicons-information-circle',
+    success: 'i-heroicons-check-circle',
+    warning: 'i-heroicons-exclamation-circle',
+    danger: 'i-heroicons-x-circle',
+    info: 'i-heroicons-information-circle',
+    color: {
+      success: 'text-[#68D391] dark:text-[#68D391]',
+      warning: 'text-[#F6AD55] dark:text-[#F6AD55]',
+      danger: 'text-[#FC8181] dark:text-[#FC8181]',
+      info: 'text-[#63B3ED] dark:text-[#63B3ED]',
+    }
   },
   // Default Tailwind CSS values
   default: {


### PR DESCRIPTION
## In This PR

### 1. Icons Render Correctly
`icon` object expanded to separately present icons and their colors using:
- `icon.[typeAlert]` - for icon selection &
- `icon.color.[typeAlert]` - for icon color selection

Resolving [issue](https://github.com/elastic-hub/docs/issues/217) & [issue](https://github.com/elastic-hub/docs/issues/198)
<hr>

_For further information visit: [http://localhost:3000/guidelines/components/sh-alert](http://localhost:3000/guidelines/components/sh-alert)_