### PR TITLE
Additional layouts for ShMicrocard

### DIFF
--- a/components/content/sh-micro-card.vue
+++ b/components/content/sh-micro-card.vue
@@ -1,7 +1,8 @@
 <template>
-  <NuxtLink :to="urlWrapper" class="not-prose" :target="target" :class="[uiLayout.wrapper]">
-    <img v-if="props.coverImage && !coverText && !coverIcon" :class="[uiLayout.coverImage]"
-      :src="props.coverImage" />
+  <component :is="layout === 'cta' ? 'div' : NuxtLinkComponent"
+    v-bind="layout === 'cta' ? {} : { to: props.urlWrapper, target: props.target }"
+    :class="['not-prose', uiLayout.wrapper]" :target="layout === 'cta' ? undefined : props.target">
+    <img v-if="props.coverImage && !coverText && !coverIcon" :class="[uiLayout.coverImage]" :src="props.coverImage" />
     <div v-if="props.coverIcon && !coverText && !coverImage" :class="[uiLayout.coverIconWrapper]">
       <UIcon :name="props.coverIcon" :class="uiLayout.coverIcon" dynamic />
     </div>
@@ -14,10 +15,18 @@
         <UIcon v-if="icon" :name="icon" :alt="altIcon" dynamic :class="uiLayout.icon" />
         <div class="relative">
           <MDC v-if="title"
-            :class="[uiLayout.title, 'transition-opacity duration-300', { 'group-hover:text-transparent': clipboard === true }]"
+            :class="[uiLayout.title, layout === 'cta' && title && !subtitle ? uiLayout.underline : '', 'transition-opacity duration-300', { 'group-hover:text-transparent': clipboard === true }]"
             :value="title" />
-          <MDC v-if="subtitle" :class="[uiLayout.subtitle, 'transition-opacity duration-300']" :value="subtitle" />
+          <MDC v-if="subtitle"
+            :class="[uiLayout.subtitle, layout === 'cta' && subtitle ? uiLayout.underline : '', 'transition-opacity duration-300']"
+            :value="subtitle" />
           <MDC v-if="text" :class="[uiLayout.text, 'transition-opacity duration-300']" :value="text" />
+          <div v-if="layout === 'cta'" class="flex justify-start">
+            <NuxtLink :to="urlButton" :target="target" class="inline-block">
+              <UIcon name="line-md:chevron-right-circle"
+                class="mt-24 mb-4 text-6xl hover:scale-105 duration-300 text-neutral-900 dark:text-golden" />
+            </NuxtLink>
+          </div>
         </div>
         <div v-if="clipboard"
           class="absolute inset-0 flex items-start justify-center opacity-0 group-hover:opacity-100 group-hover:cursor-pointer transition-opacity duration-300">
@@ -28,11 +37,12 @@
         </div>
       </div>
     </div>
-  </NuxtLink>
+  </component>
 </template>
 
 <script setup lang="ts">
 import { microCard as config } from '@/ui.config' // Importing the config file
+const NuxtLinkComponent = resolveComponent("NuxtLink"); //dynamically resolving the NuxtLink component to avoid build errors
 
 const props = withDefaults(
   defineProps<{
@@ -42,6 +52,7 @@ const props = withDefaults(
     coverIcon?: string;
     coverText?: string;
     urlWrapper?: string;
+    urlButton?: string;
     target?: string;
     urlImage?: string;
     altImage?: string;
@@ -61,6 +72,7 @@ const props = withDefaults(
     coverIcon: "",
     coverText: "",
     urlWrapper: "",
+    urlButton: "",
     target: "_self",
     urlImage: "",
     altImage: "",

--- a/content/40.join/4030.list_members/index.md
+++ b/content/40.join/4030.list_members/index.md
@@ -14,9 +14,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -33,9 +34,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -52,9 +54,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -71,9 +74,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -90,9 +94,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -107,9 +112,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -126,9 +132,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -151,10 +158,10 @@ cols: 4
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-hidden
-            wrapper: h-24
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -177,9 +184,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -196,9 +204,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -215,9 +224,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -234,9 +244,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -253,9 +264,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -272,9 +284,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -289,9 +302,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -308,9 +322,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -327,9 +342,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -344,9 +360,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -370,9 +387,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -387,9 +405,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -404,9 +423,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -421,9 +441,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -440,9 +461,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -457,9 +479,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -474,9 +497,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -491,9 +515,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -508,9 +533,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -525,9 +551,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -542,9 +569,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -561,9 +589,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello
@@ -580,9 +609,10 @@ cols: 5
     :::ShMicroCard
     ---
     ui:
-        flat:
-            coverImage: dark:bg-white bg-white overflow-none
-    layout: flat
+        logo:
+            wrapper: h-32
+            title: flex justify-center mt-8
+    layout: logo
     #opacity: true
     #coverIcon: 
     #coverText: Hello

--- a/content/8.guidelines/2.components/sh-micro-card.md
+++ b/content/8.guidelines/2.components/sh-micro-card.md
@@ -234,14 +234,12 @@ ui:
   #coverIcon: lineicons:nasa
   #coverText: NASA The Moon
   icon: lineicons:nasa
-  urlButton: https://science.nasa.gov/moon/
+  urlButton: https://www.nasa.gov/
   target: _blank
   title: |
-    The Moon
+    NASA
   subtitle: |
-    Earth`s Companion
-  text: |
-    From lighting up our skies to maintaining a geological record of our solar system’s history, Earth’s closest celestial neighbor plays a pivotal role in the study of our planet and our solar system. 
+    Beyond the Frontier 
   ---
   :::
 
@@ -266,6 +264,21 @@ ui:
   ```
 
   ```mdc
+  ::ShMicroCard
+  ---
+  layout: logo
+  coverImage: https://gpm.nasa.gov/sites/default/files/document_files/NASA-Logo-Large.png
+  #coverIcon: lineicons:nasa
+  #coverText: NASA The Moon
+  icon: lineicons:nasa
+  urlButton: https://www.nasa.gov/
+  target: _blank
+  title: |
+    NASA
+  subtitle: |
+    Beyond the Frontier 
+  ---
+  ::
   ```
 ::
 
@@ -347,7 +360,7 @@ The <b>{{ $doc.constructorName }}</b> constructor represents a micro card that c
       <td><code>layout</code></td>
       <td>n/a</td>
       <td><code>default</code></td>
-      <td>This property allows us to change layout of a constructor which in effect has that our styling is changing and we get different look and effect out of the same component. <b>Options:</b> <code>default</code>, <code>flat</code>, <code>teaser</code>, <code>translate</code> & <code>opacity</code></td>
+      <td>This property allows us to change layout of a constructor which in effect has that our styling is changing and we get different look and effect out of the same component. <b>Options:</b> <code>default</code>, <code>flat</code>, <code>teaser</code>, <code>translate</code>, <code>opacity</code>, <code>cta</code> & <code>logo</code></td>
     </tr>
     <tr>
       <td><code>urlWrapper</code></td>
@@ -484,7 +497,7 @@ These style properties can be modified via `ui` and are stored in the <code><b>{
 ```ts
 export default {
   default: {
-    wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl pl-4 pr-4 pb-4 mx-auto max-w-md w-full h-full justify-items-center text-center hover:shadow-lg hover:scale-105 duration-300 border-2 bg-golden/[0.4] border-golden/[0.6] hover:border-golden dark:bg-neutral-700 dark:border-neutral-600 dark:hover:border-golden",
+    wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl pl-4 pr-4 pb-4 pt-4 mx-auto max-w-md w-full h-full justify-items-center text-center hover:shadow-lg hover:scale-105 duration-300 border-2 bg-golden/[0.4] border-golden/[0.6] hover:border-golden dark:bg-neutral-700 dark:border-neutral-600 dark:hover:border-golden",
     coverImage: "absolute mb-0 bottom-0 left-0 w-full h-full object-fill opacity-100 ease-in-out z-40",
     coverText: "absolute inset-0 flex items-center justify-center text-center ease-in-out dark:bg-neutral-800 bg-white opacity-100 z-40",
     coverIconWrapper: "bg-white dark:bg-neutral-800 absolute inset-0 w-full h-full object-cover z-40",
@@ -497,10 +510,6 @@ export default {
   },
   flat: {
     wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl p-4 mx-auto max-w-md w-full h-full justify-items-center text-center bg-transparent dark:bg-transparent",
-    //coverImage: "absolute mb-0 bottom-0 left-0 w-full h-full object-fill opacity-100 ease-in-out z-40",
-    //coverText: "absolute inset-0 flex items-center justify-center text-center ease-in-out dark:bg-neutral-800 bg-white opacity-100 z-40",
-    //coverIconWrapper: "bg-white dark:bg-neutral-800 absolute inset-0 w-full h-full object-cover z-40",
-    //coverIcon: "absolute inset-0 w-full h-full object-cover opacity-100 ease-in-out z-40",
     image: "relative mt-4 w-full h-auto flex shrink mx-auto z-20",
     icon: "relative sm:mt-4 mb-8 flex shrink-0 mx-auto text-[4rem] z-20",
     title: "title text-2xl font-medium text-black dark:text-white break-words z-20",
@@ -542,98 +551,35 @@ export default {
     title: "title text-xl font-medium text-black dark:text-white break-words z-20",
     subtitle: "subtitle text-base font-thin dark:font-thin text-neutral-500 dark:text-gray-400 mt-3 break-words z-20",
     text: "text font-light text-[1.1rem] mt-7 break-words z-20",
+  },
+  cta: {
+    wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl p-4 mx-auto max-w-md w-full h-full justify-items-center text-center border-2 bg-golden/[0.4] border-golden/[0.6]",
+    coverImage: "absolute inset-0 w-full h-full object-cover opacity-60 dark:opacity-60 z-0",
+    coverText: "absolute inset-0 flex items-center justify-center text-center opacity-60 z-0",
+    coverIconWrapper: "absolute inset-0 w-full h-full flex items-center justify-center z-0",
+    coverIcon: "absolute inset-0 w-full h-full object-cover opacity-60 z-0",
+    image: "relative mt-4 w-full h-auto flex shrink mx-auto z-20",
+    icon: "relative text-start sm:mt-4 mb-8 flex shrink-0 text-[3rem] z-20",
+    title: "title text-4xl text-start font-medium text-black dark:text-white break-words z-20",
+    subtitle: "subtitle text-2xl text-start font-thin dark:font-thin text-neutral-900 dark:text-neutral-300 mt-1 break-words z-20",
+    underline: "underline underline-offset-[1.5rem] decoration-2 decoration-gray-700 dark:decoration-golden/[0.4]",
+    text: "text mt-8 font-light text-[1.1rem] text-start text-neutral-800 dark:text-golden break-words z-20",
+  },
+  logo: {
+    wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl pl-3 pr-3 mx-auto max-w-md w-full h-full justify-items-center text-center border-2 border-golden/[0.6] hover:border-golden dark:border-neutral-600 dark:hover:border-golden",
+    coverImage: "absolute mb-0 bottom-0 left-0 w-full h-full object-contain bg-white transition-transform duration-700 group-hover:-translate-y-full z-40",
+    coverText: "absolute inset-0 flex items-center justify-center text-center dark:bg-neutral-800 bg-white transition-transform duration-700 group-hover:-translate-y-full z-40",
+    coverIconWrapper: "bg-white dark:bg-neutral-800 absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:-translate-y-full z-40",
+    coverIcon: "absolute inset-0 w-full h-full object-cover opacity-100 ease-in-out z-40",
+    image: "relative mt-4 w-full h-auto flex shrink mx-auto z-20",
+    icon: "relative sm:mt-4 mb-8 text-[8rem] flex shrink-0 mx-auto text-oma-blue-900/[0.7] hover:text-oma-blue-600 dark:text-oma-blue-200 z-20",
+    title: "title text-xl font-medium text-black dark:text-white break-words z-20",
+    subtitle: "subtitle text-base font-thin dark:font-thin text-neutral-500 dark:text-gray-400 mt-3 break-words z-20",
+    text: "text font-light text-[1.1rem] mt-7 break-words z-20",
   }
 }
 ```
 
 #### Class Descriptions
 
-These class values are used in the <b>{{ $doc.constructorName }}</b> component. The values are customizable and can be adjusted through the `ui` properties' attributes.
-
-</br>
-
-- <code>default:</code></br>
-
-  **_wrapper_**
-  - **Value**: `"container overflow-hidden relative group flex flex-col rounded-2xl p-4 mx-auto max-w-md w-full h-full justify-items-center text-center hover:shadow-lg hover:scale-105 duration-300 border-2 bg-golden/[0.4] border-golden/[0.6] hover:border-golden dark:bg-neutral-700 dark:border-neutral-600 dark:hover:border-golden"`
-  - **Description**: A flexible container with a column layout, rounded corners, padding, centered alignment, and a maximum width of medium size. Includes hover effects for scaling, shadow, and border color changes. The component adapts to both light and dark modes with respective background and border styles.
-
-  **_coverImage_**
-  - **Value**: `"absolute mb-0 bottom-0 left-0 w-full h-full object-fill opacity-100 ease-in-out z-40"`
-  - **Description**: Positions the cover image absolutely at the bottom left, stretching it across the full width and height. The image will fill the container and maintain full opacity with smooth transition effects.
-
-  **_coverText_**
-  - **Value**: `"absolute inset-0 flex items-center justify-center text-center ease-in-out dark:bg-neutral-800 bg-white opacity-100 z-40"`
-  - **Description**: Centers the cover text within the container, positioning it absolutely across the entire area. The text is centered both vertically and horizontally with smooth transition effects. The background color changes for light and dark modes.
-
-  **_coverIconWrapper_**
-  - **Value**: `"bg-white dark:bg-neutral-800 absolute inset-0 w-full h-full object-cover z-40"`
-  - **Description**: A wrapper for the cover icon, positioned absolutely across the entire area. It has a background that adapts to light and dark modes and covers the container's full size.
-
-  **_coverIcon_**
-  - **Value**: `"absolute inset-0 w-full h-full object-cover opacity-100 ease-in-out z-40"`
-  - **Description**: Positions the cover icon absolutely across the container, ensuring it covers the entire area. The icon has full opacity and is contained within the wrapper with smooth transition effects.
-
-  **_image_**
-  - **Value**: `"relative mt-4 w-full h-auto flex shrink mx-auto z-20"`
-  - **Description**: Positions the image relatively with a top margin, full width, and automatic height. The image is centered horizontally with flexible shrinking behavior and placed in front of the cover elements.
-
-  **_icon_**
-  - **Value**: `"relative sm:mt-4 w-10 h-10 flex shrink-0 mx-auto text-oma-blue-900/[0.7] hover:text-oma-blue-600 dark:text-oma-blue-200 z-20"`
-  - **Description**: A small icon with relative positioning, flexible behavior, centered alignment, and responsive top margin. It includes light and dark mode blue text colors with hover effects.
-
-  **_title_**
-  - **Value**: `"title text-xl font-medium text-black dark:text-white break-words z-20"`
-  - **Description**: Applies medium-weight, large-sized text with black coloring (light mode) or white coloring (dark mode). Allows text wrapping for long words and is placed above other elements in the stack.
-
-  **_subtitle_**
-  - **Value**: `"subtitle text-base font-thin dark:font-thin text-neutral-500 dark:text-gray-400 mt-3 break-words z-20"`
-  - **Description**: A thin, base-sized text style with neutral or gray coloring, a top margin, and wrapping for long words. Font weight adjusts for dark mode.
-
-  **_text_**
-  - **Value**: `"text font-light text-[1.1rem] mt-7 break-words z-20"`
-  - **Description**: Default text style with medium size, top margin, and wrapping for long words. Positioned above other content.
-
-<hr>
-
-- <code>flat:</code></br>
-
-  **_wrapper_**
-  - **Value**: `"container overflow-hidden relative group flex flex-col rounded-2xl p-4 mx-auto max-w-md w-full h-full justify-items-center text-center bg-transparent dark:bg-transparent"`
-  - **Description**: A flexible container with a column layout and rounded corners. It includes padding, centers its content both vertically and horizontally, and adapts to different screen sizes with a maximum width of medium size. The background is transparent in both light and dark modes.
-
-  **_coverImage_**
-  - **Value**: `"absolute mb-0 bottom-0 left-0 w-full h-full object-fill opacity-100 ease-in-out z-40"`
-  - **Description**: Positions the cover image absolutely at the bottom left, stretching it across the full width and height. The image will fill the container and maintain full opacity with smooth transition effects.
-
-  **_coverText_**
-  - **Value**: `"absolute inset-0 flex items-center justify-center text-center ease-in-out dark:bg-neutral-800 bg-white opacity-100 z-40"`
-  - **Description**: Centers the cover text within the container, positioning it absolutely across the entire area. The text is centered both vertically and horizontally with smooth transition effects. The background color changes for light and dark modes.
-
-  **_coverIconWrapper_**
-  - **Value**: `"bg-white dark:bg-neutral-800 absolute inset-0 w-full h-full object-cover z-40"`
-  - **Description**: A wrapper for the cover icon, positioned absolutely across the entire area. It has a background that adapts to light and dark modes and covers the container's full size.
-
-  **_coverIcon_**
-  - **Value**: `"absolute inset-0 w-full h-full object-cover opacity-100 ease-in-out z-40"`
-  - **Description**: Positions the cover icon absolutely across the container, ensuring it covers the entire area. The icon has full opacity and is contained within the wrapper with smooth transition effects.
-
-  **_image_**
-  - **Value**: `"relative mt-4 w-full h-auto flex shrink mx-auto z-20"`
-  - **Description**: Positions the image relatively with a top margin, full width, and automatic height. The image is centered horizontally with flexible shrinking behavior and placed in front of the cover elements.
-
-  **_icon_**
-  - **Value**: `"relative sm:mt-4 w-10 h-10 flex shrink-0 mx-auto text-oma-blue-900/[0.7] hover:text-oma-blue-600 dark:text-oma-blue-200 z-20"`
-  - **Description**: A small icon with relative positioning, flexible behavior, centered alignment, and responsive top margin. It includes light and dark mode blue text colors with hover effects.
-
-  **_title_**
-  - **Value**: `"title text-xl font-medium text-black dark:text-white break-words z-20"`
-  - **Description**: Applies medium-weight, large-sized text with black coloring (light mode) or white coloring (dark mode). Allows text wrapping for long words and is placed above other elements in the stack.
-
-  **_subtitle_**
-  - **Value**: `"subtitle text-base font-thin dark:font-thin text-neutral-500 dark:text-gray-400 mt-3 break-words z-20"`
-  - **Description**: A thin, base-sized text style with neutral or gray coloring, a top margin, and wrapping for long words. Font weight adjusts for dark mode.
-
-  **_text_**
-  - **Value**: `"text font-light text-[1.1rem] mt-7 break-words z-20"`
-  - **Description**: Default text style with medium size, top margin, and wrapping for long words. Positioned above other content.
+This constructor has many classes in many layouts, so this description section would be exagerated with information about each class. Checkout the official [TailwindCSS](https://v3.tailwindcss.com/) documentation.

--- a/content/8.guidelines/2.components/sh-micro-card.md
+++ b/content/8.guidelines/2.components/sh-micro-card.md
@@ -229,7 +229,7 @@ ui:
 
   :::ShMicroCard
   ---
-  #layout: logo
+  layout: logo
   coverImage: https://gpm.nasa.gov/sites/default/files/document_files/NASA-Logo-Large.png
   #coverIcon: lineicons:nasa
   #coverText: NASA The Moon

--- a/content/8.guidelines/2.components/sh-micro-card.md
+++ b/content/8.guidelines/2.components/sh-micro-card.md
@@ -62,12 +62,26 @@ text: |
 
 <b>{{ $doc.constructorName }}</b> constructor also comes with a `layout` option:
 
+::ShAlert
+---
+typeAlert: warning
+---
+The layout: `flat` does **NOT** support `coverImage`, `coverIcon` nor `coverText` props. 
+::
+
+::ShAlert
+---
+typeAlert: warning
+---
+The layout: `cta` does **NOT** have a `urlWrapper`. Instead, use `urlButton` 
+::
+
 ::ShTwoColumns
 ---
 ui:
   wrapper: bg-inherit dark:bg-inherit shadow-none
 ---
-  <!--First Two Layouts-->
+  <!--1st row-->
   :::ShMicroCard
   ---
   layout: translate
@@ -102,7 +116,7 @@ ui:
   ---
   :::
 
-  <!--How to construct them-->
+  <!--2nd row-->
   ```mdc
   ::ShMicroCard
   ---
@@ -141,7 +155,7 @@ ui:
   ::
   ```
 
-  <!--Second Two Layouts-->
+  <!--3rd row-->
   :::ShMicroCard
   ---
   layout: flat
@@ -173,7 +187,7 @@ ui:
   ---
   :::
 
-  <!--How to construct them-->
+  <!--4th row-->
   ```mdc
   ::ShMicroCard
   ---
@@ -209,6 +223,7 @@ ui:
   ::
   ```
 
+  <!--5th row-->
   :::ShMicroCard
   ---
   layout: cta
@@ -243,6 +258,7 @@ ui:
   ---
   :::
 
+  <!--6th row-->
   ```mdc
   ::ShMicroCard
   ---

--- a/content/8.guidelines/2.components/sh-micro-card.md
+++ b/content/8.guidelines/2.components/sh-micro-card.md
@@ -28,8 +28,10 @@ ui:
 ---
   :::ShMicroCard
   ---
-  urlImage: https://gpm.nasa.gov/sites/default/files/document_files/NASA-Logo-Large.png
+  #urlImage: https://gpm.nasa.gov/sites/default/files/document_files/NASA-Logo-Large.png
+  icon: lineicons:nasa
   urlWrapper: https://www.nasa.gov/
+  target: _blank
   title: |
       NASA 
   subtitle: |
@@ -45,8 +47,9 @@ This is how it is constructed
 ```mdc
 ::ShMicroCard
 ---
-urlImage: https://gpm.nasa.gov/sites/default/files/document_files/NASA-Logo-Large.png
 urlWrapper: https://www.nasa.gov/
+target: _blank
+icon: lineicons:nasa
 title: |
   NASA 
 subtitle: |
@@ -59,13 +62,12 @@ text: |
 
 <b>{{ $doc.constructorName }}</b> constructor also comes with a `layout` option:
 
-<!--First Two Layouts-->
-::ShMultiColumn
+::ShTwoColumns
 ---
 ui:
-  wrapper: p-10 flex-col
-cols: 2
+  wrapper: bg-inherit dark:bg-inherit shadow-none
 ---
+  <!--First Two Layouts-->
   :::ShMicroCard
   ---
   layout: translate
@@ -99,60 +101,47 @@ cols: 2
       Venus is the second planet from the Sun, and the sixth largest planet. It’s the hottest planet in our solar system.
   ---
   :::
-::
 
-<!--How to construct them-->
-::ShMultiColumn
----
-cols: 2
----
-```mdc
-::ShMicroCard
----
-layout: translate
-coverImage: https://science.nasa.gov/wp-content/uploads/2023/11/mercury-messenger-globe-pia15162.jpg
-#coverIcon: lineicons:nasa
-#coverText: NASA Mercury
-icon: game-icons:planet-core
-urlWrapper: https://science.nasa.gov/mercury/
-title: |
-  Mercury
-subtitle: |
-  God of Translators and Interpreters
-text: |
-  The smallest planet in our solar system and nearest to the Sun, Mercury is only slightly larger than Earth's Moon. 
----
-::
-```
+  <!--How to construct them-->
+  ```mdc
+  ::ShMicroCard
+  ---
+  layout: translate
+  coverImage: https://science.nasa.gov/wp-content/uploads/2023/11/mercury-messenger-globe-pia15162.jpg
+  #coverIcon: lineicons:nasa
+  #coverText: NASA Mercury
+  icon: game-icons:planet-core
+  urlWrapper: https://science.nasa.gov/mercury/
+  title: |
+    Mercury
+  subtitle: |
+    God of Translators and Interpreters
+  text: |
+    The smallest planet in our solar system and nearest to the Sun, Mercury is only slightly larger than Earth's Moon. 
+  ---
+  ::
+  ```
 
-```mdc
-::ShMicroCard
----
-layout: opacity
-coverImage: https://science.nasa.gov/wp-content/uploads/2023/05/venus-single.png?w=398
-#coverIcon: lineicons:nasa
-#coverText: NASA Venus
-icon: fa6-solid:user-astronaut
-urlWrapper: https://science.nasa.gov/venus/
-title: |
-  Venus 
-subtitle: |
-  How hot is too hot?
-text: |
-  Venus is the second planet from the Sun, and the sixth largest planet. It’s the hottest planet in our solar system.
----
-::
-```
-::
+  ```mdc
+  ::ShMicroCard
+  ---
+  layout: opacity
+  coverImage: https://science.nasa.gov/wp-content/uploads/2023/05/venus-single.png?w=398
+  #coverIcon: lineicons:nasa
+  #coverText: NASA Venus
+  icon: fa6-solid:user-astronaut
+  urlWrapper: https://science.nasa.gov/venus/
+  title: |
+    Venus 
+  subtitle: |
+    How hot is too hot?
+  text: |
+    Venus is the second planet from the Sun, and the sixth largest planet. It’s the hottest planet in our solar system.
+  ---
+  ::
+  ```
 
-<!--Second Two Layouts-->
-
-::ShMultiColumn
----
-ui:
-  wrapper: p-10 flex-col
-cols: 2
----
+  <!--Second Two Layouts-->
   :::ShMicroCard
   ---
   layout: flat
@@ -183,47 +172,101 @@ cols: 2
       Mars is the fourth planet from the Sun, and the seventh largest. It’s the only planet we know of inhabited entirely by robots
   ---
   :::
-::
 
-<!--How to construct them-->
-::ShMultiColumn
----
-cols: 2
----
-```mdc
-::ShMicroCard
----
-layout: flat
-icon: gis:earth-euro-africa-o
-urlWrapper: https://science.nasa.gov/earth/facts/
-title: |
-  Earth 
-subtitle: |
-  The Blue Marble
-text: |
-  Earth – our home planet – is the third planet from the Sun, and the fifth largest planet. It's the only place we know of inhabited by living things.
----
-::
-```
+  <!--How to construct them-->
+  ```mdc
+  ::ShMicroCard
+  ---
+  layout: flat
+  icon: gis:earth-euro-africa-o
+  urlWrapper: https://science.nasa.gov/earth/facts/
+  title: |
+    Earth 
+  subtitle: |
+    The Blue Marble
+  text: |
+    Earth – our home planet – is the third planet from the Sun, and the fifth largest planet. It's the only place we know of inhabited by living things.
+  ---
+  ::
+  ```
 
-```mdc
-::ShMicroCard
----
-layout: teaser
-coverImage: https://scx2.b-cdn.net/gfx/news/hires/2015/interestingf.jpg
-#coverIcon: lineicons:nasa
-#coverText: NASA Mars
-icon: token-branded:safemars
-urlWrapper: https://science.nasa.gov/mars/
-title: |
-  Mars 
-subtitle: |
-  Meet the neighbour
-text: |
-  Mars is the fourth planet from the Sun, and the seventh largest. It’s the only planet we know of inhabited entirely by robots
----
-::
-```
+  ```mdc
+  ::ShMicroCard
+  ---
+  layout: teaser
+  coverImage: https://scx2.b-cdn.net/gfx/news/hires/2015/interestingf.jpg
+  #coverIcon: lineicons:nasa
+  #coverText: NASA Mars
+  icon: token-branded:safemars
+  urlWrapper: https://science.nasa.gov/mars/
+  title: |
+    Mars 
+  subtitle: |
+    Meet the neighbour
+  text: |
+    Mars is the fourth planet from the Sun, and the seventh largest. It’s the only planet we know of inhabited entirely by robots
+  ---
+  ::
+  ```
+
+  :::ShMicroCard
+  ---
+  layout: cta
+  coverImage: https://moon.nasa.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBczBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--5cd8ec175a88e67be34ecfc8fe179be81b0a7561/176_moon_2018-04-23-Tom_Campbell_1600.jpg
+  #coverIcon: lineicons:nasa
+  #coverText: NASA The Moon
+  icon: streamline-emojis:new-moon
+  urlButton: https://science.nasa.gov/moon/
+  target: _blank
+  title: |
+    The Moon
+  subtitle: |
+    Earth`s Companion
+  text: |
+    From lighting up our skies to maintaining a geological record of our solar system’s history, Earth’s closest celestial neighbor plays a pivotal role in the study of our planet and our solar system. 
+  ---
+  :::
+
+  :::ShMicroCard
+  ---
+  #layout: logo
+  coverImage: https://gpm.nasa.gov/sites/default/files/document_files/NASA-Logo-Large.png
+  #coverIcon: lineicons:nasa
+  #coverText: NASA The Moon
+  icon: lineicons:nasa
+  urlButton: https://science.nasa.gov/moon/
+  target: _blank
+  title: |
+    The Moon
+  subtitle: |
+    Earth`s Companion
+  text: |
+    From lighting up our skies to maintaining a geological record of our solar system’s history, Earth’s closest celestial neighbor plays a pivotal role in the study of our planet and our solar system. 
+  ---
+  :::
+
+  ```mdc
+  ::ShMicroCard
+  ---
+  layout: cta #short from Call To Action
+  coverImage: https://moon.nasa.gov/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBczBEIiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--5cd8ec175a88e67be34ecfc8fe179be81b0a7561/176_moon_2018-04-23-Tom_Campbell_1600.jpg
+  #coverIcon: lineicons:nasa
+  #coverText: NASA The Moon
+  icon: streamline-emojis:new-moon
+  urlButton: https://science.nasa.gov/moon/
+  target: _blank
+  title: |
+    The Moon
+  subtitle: |
+    Earth`s Companion
+  text: |
+    From lighting up our skies to maintaining a geological record of our solar system’s history, Earth’s closest celestial neighbor plays a pivotal role in the study of our planet and our solar system. 
+  ---
+  ::
+  ```
+
+  ```mdc
+  ```
 ::
 
 ### Props

--- a/ui.config/sh-micro-card.ts
+++ b/ui.config/sh-micro-card.ts
@@ -58,5 +58,18 @@ export default {
     title: "title text-xl font-medium text-black dark:text-white break-words z-20",
     subtitle: "subtitle text-base font-thin dark:font-thin text-neutral-500 dark:text-gray-400 mt-3 break-words z-20",
     text: "text font-light text-[1.1rem] mt-7 break-words z-20",
-  }
+  },
+  cta: {
+    wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl p-4 mx-auto max-w-md w-full h-full justify-items-center text-center border-2 bg-golden/[0.4] border-golden/[0.6]",
+    coverImage: "absolute inset-0 w-full h-full object-cover opacity-60 dark:opacity-60 z-0",
+    coverText: "absolute inset-0 flex items-center justify-center text-center opacity-60 z-0",
+    coverIconWrapper: "absolute inset-0 w-full h-full flex items-center justify-center z-0",
+    coverIcon: "absolute inset-0 w-full h-full object-cover opacity-60 z-0",
+    image: "relative mt-4 w-full h-auto flex shrink mx-auto z-20",
+    icon: "relative text-start sm:mt-4 mb-8 flex shrink-0 text-[3rem] z-20",
+    title: "title text-4xl text-start font-medium text-black dark:text-white break-words z-20",
+    subtitle: "subtitle text-2xl text-start font-thin dark:font-thin text-neutral-900 dark:text-neutral-300 mt-1 break-words z-20",
+    underline: "underline underline-offset-[1.5rem] decoration-2 decoration-gray-700 dark:decoration-golden/[0.4]",
+    text: "text mt-8 font-light text-[1.1rem] text-start text-neutral-800 dark:text-golden break-words z-20",
+  },
 }

--- a/ui.config/sh-micro-card.ts
+++ b/ui.config/sh-micro-card.ts
@@ -72,4 +72,16 @@ export default {
     underline: "underline underline-offset-[1.5rem] decoration-2 decoration-gray-700 dark:decoration-golden/[0.4]",
     text: "text mt-8 font-light text-[1.1rem] text-start text-neutral-800 dark:text-golden break-words z-20",
   },
+  logo: {
+    wrapper: "container overflow-hidden relative group flex flex-col rounded-2xl pl-3 pr-3 mx-auto max-w-md w-full h-full justify-items-center text-center border-2 border-golden/[0.6] hover:border-golden dark:border-neutral-600 dark:hover:border-golden",
+    coverImage: "absolute mb-0 bottom-0 left-0 w-full h-full object-contain bg-white transition-transform duration-700 group-hover:-translate-y-full z-40",
+    coverText: "absolute inset-0 flex items-center justify-center text-center dark:bg-neutral-800 bg-white transition-transform duration-700 group-hover:-translate-y-full z-40",
+    coverIconWrapper: "bg-white dark:bg-neutral-800 absolute inset-0 w-full h-full object-cover transition-transform duration-700 group-hover:-translate-y-full z-40",
+    coverIcon: "absolute inset-0 w-full h-full object-cover opacity-100 ease-in-out z-40",
+    image: "relative mt-4 w-full h-auto flex shrink mx-auto z-20",
+    icon: "relative sm:mt-4 mb-8 text-[8rem] flex shrink-0 mx-auto text-oma-blue-900/[0.7] hover:text-oma-blue-600 dark:text-oma-blue-200 z-20",
+    title: "title text-xl font-medium text-black dark:text-white break-words z-20",
+    subtitle: "subtitle text-base font-thin dark:font-thin text-neutral-500 dark:text-gray-400 mt-3 break-words z-20",
+    text: "text font-light text-[1.1rem] mt-7 break-words z-20",
+  }
 }


### PR DESCRIPTION
## In This PR:

### [1. Added `cta` layout](https://github.com/elastic-hub/docs/issues/225)
This layout helps with a more click-to-action type of content, with a button that will guide you to the desired source instead of `urlWrapper` (this prop does **NOT** exist in this layout).

### 2. Added `logo` layout
Although this layout doesn\`t seem to look like it can be used as a repeated logo constructor, when paired with `ShMultiColumn` and some additional styling, it can have nice effects. It would be good to use the .png format.

### 3. Guidelines updates
The following updates are tracked back in the guidelines.

<hr>

_For more information, visit http://localhost:3000/guidelines/components/sh-micro-card & http://localhost:3000/join/list_members_