### PR TITLE
Issue 228

### DIFF
--- a/components/app/menus.vue
+++ b/components/app/menus.vue
@@ -5,7 +5,7 @@
             <button @click="item.onClick" :class="[
                 item.label === 'HOME'
                     ? 'hover:rounded-lg cursor-pointer'
-                    : 'hover:rounded-t-lg cursor-default',
+                    : 'hover:rounded-t-lg cursor-pointer',
                 ui.rootMenuButton
             ]">
                 <span class="flex items-center space-x-2">
@@ -174,7 +174,7 @@ const processNavigationItem = (navItem: any, isRoot = true): MenuItem => {
         label: navItem.title,
         path: navItem._path, // Keep the index path for active-checking
         children: navItem.children?.map((child: any) => processNavigationItem(child, false)) || null,
-        onClick: isRoot ? undefined : () => router.push(navItem._path) // Only make level 2+ clickable
+        onClick: () => router.push(navItem._path) 
     };
 };
 

--- a/content/20.solutions/2005.index.md
+++ b/content/20.solutions/2005.index.md
@@ -1,6 +1,7 @@
 ---
 title: OMA's IoT Solutions
 description:
+navigation: false
 layout: web
 icon: carbon:data-quality-definition
 ---

--- a/content/30.specifications/3005.index.md
+++ b/content/30.specifications/3005.index.md
@@ -1,6 +1,7 @@
 ---
 title: OMA Specifications
 description:
+navigation: false
 layout: web
 icon: carbon:data-quality-definition
 ---

--- a/content/40.join/4005.index.md
+++ b/content/40.join/4005.index.md
@@ -1,6 +1,7 @@
 ---
 title: Join OMA
 description:
+navigation: false
 layout: web
 icon: material-symbols-light:join-left
 ---

--- a/content/45.ucifi/4005.index.md
+++ b/content/45.ucifi/4005.index.md
@@ -1,6 +1,7 @@
 ---
 title: uCIFI
 description:
+navigation: false
 layout: web
 ---
 

--- a/content/50.members/5005.index.md
+++ b/content/50.members/5005.index.md
@@ -1,6 +1,7 @@
 ---
 title: Members
 description:
+navigation: false
 layout: web
 icon: tdesign:member-filled
 ---

--- a/content/60.media/6005.index.md
+++ b/content/60.media/6005.index.md
@@ -1,6 +1,7 @@
 ---
 title: Media
 description:
+navigation: false
 layout: web
 icon: emojione-monotone:newspaper
 ---

--- a/content/65.oma-events/6505.index.md
+++ b/content/65.oma-events/6505.index.md
@@ -1,6 +1,7 @@
 ---
 title: Events
 description:
+navigation: false
 layout: doc
 icon: material-symbols-light:event-upcoming-outline-rounded
 ---

--- a/content/70.about/7005.index.md
+++ b/content/70.about/7005.index.md
@@ -1,6 +1,7 @@
 ---
 title: About
 description:
+navigation: false
 layout: 
 icon: flat-color-icons:about
 ---


### PR DESCRIPTION
## In this PR

### 1. Excluded `index` Files From Root Folders, In The Navigation
Accessing `index` files is now available by clicking on root folder (main menu)

### 2. Root Folders Clickable
In order to access the `index` file, these folders are now clickable

> Note: In hamburger menu this is not the case