### PR TITLE
UCIFI Webinar

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -172,6 +172,7 @@ h7 {
 .dark em,
 .dark ul,
 .dark ol,
+.dark ::marker,
 .dark td,
 .dark th {
   color: theme('colors.golden');

--- a/content/landing-page-menu.md
+++ b/content/landing-page-menu.md
@@ -3,104 +3,95 @@ title: # Optional
 description: # Optional
 ---
 
-::ShSegment
----
-ui:
-    wrapper: group grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-5 opacity-75
----
-    :::ShMicroCard
+::ShColumn
+    ::ShSegment
     ---
     ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col 
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-file-document-box-outline
-    title: OMA SpecWorks
-    urlWrapper: /omaspecworks/
+        wrapper: group grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 sm:gap-5 opacity-75
     ---
-    :::
+        :::ShMicroCard
+        ---
+        icon: i-mdi-file-document-box-outline
+        title: OMA SpecWorks
+        urlWrapper: /omaspecworks/
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        icon: i-mdi-file-cog-outline
+        title: Specifications
+        urlWrapper: /specifications/
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        icon: i-mdi-cellphone-wireless
+        title: LwM2M
+        urlWrapper: "/lwm2m/"
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        icon: i-mdi-wrench-outline
+        title: Utilities
+        urlWrapper: "/utilities/"
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        icon: mdi:city-variant-outline
+        title: uCIFI
+        urlWrapper: "/ucifi/"
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        icon: i-mdi-newspaper-variant-outline
+        title: News
+        urlWrapper: "/news/"
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        icon: i-mdi-calendar-check-outline
+        title: Events
+        urlWrapper: "/oma-events/"
+        ---
+        :::
+
+        :::ShMicroCard
+        ---
+        #ui:
+            #wrapper: h-20 sm:h-full sm:w-full flex flex-col
+            #icon: w-1/3 text-blue-400
+            #title: text-white text-xs sm:text-lg
+        icon: i-mdi-tools
+        title: Tools
+        urlWrapper: "/tools/"
+        ---
+        :::
+    ::
 
     :::ShMicroCard
     ---
     ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-file-cog-outline
-    title: Specifications
-    urlWrapper: /specifications/
-    ---
-    :::
-
-    :::ShMicroCard
-    ---
-    ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-cellphone-wireless
-    title: LwM2M
-    urlWrapper: "/lwm2m/"
-    ---
-    :::
-
-    :::ShMicroCard
-    ---
-    ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-wrench-outline
-    title: Utilities
-    urlWrapper: "/utilities/"
-    ---
-    :::
-
-    :::ShMicroCard
-    ---
-    ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: mdi:city-variant-outline
-    title: uCIFI
+        flat:
+            wrapper: border-2 mt-12 backdrop-blur-sm max-w-xl hover:backdrop-blur-md hover:scale-105 duration-500 ease-in-out hover:border-blue-500
+            title: text-white
+            subtitle: text-red-500 dark:text-red-500 font-extrabold dark:font-extrabold animate-pulse
+            icon: text-white
+    layout: flat
+    icon: mdi:video-outline
+    title: uCIFI - OMA
+    subtitle: |
+        Register for Webinar
     urlWrapper: "/ucifi/"
-    ---
-    :::
-
-    :::ShMicroCard
-    ---
-    ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-newspaper-variant-outline
-    title: News
-    urlWrapper: "/news/"
-    ---
-    :::
-
-    :::ShMicroCard
-    ---
-    ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-calendar-check-outline
-    title: Events
-    urlWrapper: "/oma-events/"
-    ---
-    :::
-
-    :::ShMicroCard
-    ---
-    ui:
-        wrapper: h-20 sm:h-full sm:w-full flex flex-col
-        icon: w-1/3 text-blue-400
-        title: text-white text-xs sm:text-lg
-    icon: i-mdi-tools
-    title: Tools
-    urlWrapper: "/tools/"
     ---
     :::
 ::


### PR DESCRIPTION
## In This PR

### 1.  UCIFI Banner Removed and Added `ShMicroCard` Instead
We assume that the `ShAnnouncement` component is making some critical errors for the website. Because of that, we deactivated it and introduced another `ShMicroCard` on the home page.

### 2. Added `.dark ::marker` to a Color Pallet
Before it was not listed in the `app.vue` in the style section, so it is implemented from this PR forward.