### PR TITLE
[ADMIN] bulk reservation objects 36050-36099 range for Orange

### DIFF
--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -278,7 +278,7 @@
     {
         "ObjectIDRange": "36000 - 36049", 
         "CompanyName": "IOX GmbH"
-    }
+    },
     {
         "ObjectIDRange": "36050 - 36099", 
         "CompanyName": "Orange"

--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -279,4 +279,8 @@
         "ObjectIDRange": "36000 - 36049", 
         "CompanyName": "IOX GmbH"
     }
+    {
+        "ObjectIDRange": "36050 - 36099", 
+        "CompanyName": "Orange"
+    }
 ]


### PR DESCRIPTION
A new bulk object reservation for Orange is available for 36050-36099, as requested per [Helpdesk Issue-OMA-75](https://openmobilealliance.atlassian.net/browse/OMA-75).