### PR TITLE
Fix COPY bug in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /src
 # Build
 FROM base as build
 
-COPY --link package.json package-lock.json .
+COPY --link package.json package-lock.json ./
 RUN npm install --production=false
 
 COPY --link . .


### PR DESCRIPTION
Fixes error

```
Step 6/16 : FROM base as build
 ---> a9d49dd345fe
Step 7/16 : COPY --link package.json package-lock.json .
When using COPY with more than one source file, the destination must be a directory and end with a /
```

when doing `docker build -t oma-knowledge-base .`