### PR TITLE
[ADMIN] bulk reservation objects 36150–36199 for Schreder

### DIFF
--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -286,5 +286,9 @@
      {
         "ObjectIDRange": "36100 - 36149", 
         "CompanyName": "Micro Connect"
-    }
+    },
+    {
+        "ObjectIDRange": "36150 - 36199", 
+        "CompanyName": "Schreder"
+     }
 ]


### PR DESCRIPTION
Bulk object reservation for Schreder: Object IDs 36150–36199, as per request in [HelpDesk-OMA-98](https://openmobilealliance.atlassian.net/jira/servicedesk/projects/OMA/queues/custom/1/OMA-98).
