### PR TITLE
[ADMIN]  bulk reservation objects 36200-36249 for Vodafone

### DIFF
--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -290,5 +290,9 @@
     {
         "ObjectIDRange": "36150 - 36199", 
         "CompanyName": "Schreder"
+     },
+     {
+        "ObjectIDRange": "36200 - 36249", 
+        "CompanyName": "Vodafone"
      }
 ]


### PR DESCRIPTION
 Bulk object reservation for Vodafone: Object IDs 36200–36249, as per request in [Helpdesk-OMA-93](https://openmobilealliance.atlassian.net/jira/servicedesk/projects/OMA/queues/custom/1/OMA-93).