### PR TITLE
[ADMIN] bulk reservation objects 36250-36299 for Hk.Digital

### DIFF
--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -294,5 +294,10 @@
      {
         "ObjectIDRange": "36200 - 36249", 
         "CompanyName": "Vodafone"
+     },
+     {
+        "ObjectIDRange": "36250 - 36299", 
+        "CompanyName": "HK.Digital"
      }
+     
 ]


### PR DESCRIPTION
Bulk object reservation for Vodafone: Object IDs 36250–36299, as per request in [Helpdesk-OMA-103](https://openmobilealliance.atlassian.net/browse/OMA-103).