### PR TITLE
feat: add app error handler to resolve missing pages

### DIFF
--- a/plugins/error-handler.ts
+++ b/plugins/error-handler.ts
@@ -1,0 +1,8 @@
+export default defineNuxtPlugin(nuxtApp => {
+  nuxtApp.hook('app:error', (err) => {
+    console.log(`APP ERROR: ${err}`)
+    clearError({ redirect: '/home' })
+    return false
+  })
+})
+


### PR DESCRIPTION
# Why You See a 500 Instead of a 404
## Nuxt 3’s Static Generation Behavior

When you run nuxi generate, Nuxt pre-renders all routes it knows about at build time. This includes:

* Pages you have explicitly created under /pages
* Any dynamic routes that you have manually provided payloads for (via prerender.routes in nuxt.config.ts or nitro.config.ts).

When someone visits a route that was not generated, Nuxt cannot find a corresponding pre-rendered HTML file. In SSG mode, this means:
* There is no .html file for that route in the dist/ folder.
* The server (or static host) falls back to serving index.html (the SPA entry point).

Nuxt tries to hydrate the app and render the page client-side.

Since the route doesn’t exist in your pages, Nuxt’s internal renderer ends up with a null page context and tries to access body on null. This leads to the 500 runtime error you see:
```Cannot read properties of null (reading 'body').```

So in short — this is not actually a "server 500" error. It is a client-side runtime error caused by Nuxt trying to render a non-existent route dynamically.

## Why You Don’t Get a 404

In SSR mode, Nuxt would send a proper 404 response because the server has a chance to run route matching before rendering.

In SSG mode, there is no server logic running at request time. Everything is pre-rendered.

If the page doesn’t exist in the dist/ folder, Nuxt can’t automatically serve a 404 page.

Without a fallback mechanism, the SPA just crashes (hence the Cannot read properties of null).

## Solution 

Use client-side navigation guards to redirect to a `safe` page.
Nuxt will call the `app:error` hook if there are any errors in starting your Nuxt application, like try to render missing page.