### PR TITLE
[ADMIN] split U-Blox reservation obj range IDs 33655-33704 to Trasna and Trident

### DIFF
--- a/public/data/lwm2m-bulk-vendor-reservations.json
+++ b/public/data/lwm2m-bulk-vendor-reservations.json
@@ -80,8 +80,12 @@
         "CompanyName": "AVSystem sp. z o.o."
     },
     {
-        "ObjectIDRange": "33655 - 33704", 
-        "CompanyName": "U-Blox"
+        "ObjectIDRange": "33655 - 33679", 
+        "CompanyName": "Trasna"
+    },
+    {
+        "ObjectIDRange": "33680 - 33704", 
+        "CompanyName": "Trident"
     },
     {
         "ObjectIDRange": "33705 - 33754", 


### PR DESCRIPTION
One of the two LwM2M Object ID ranges belonging to U-Blox is assigned to Trasna and Trident, according to https://github.com/OpenMobileAlliance/lwm2m-registry/issues/850.